### PR TITLE
Fix: Display order items on Orders page

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"food-order-tracking/internal/database"
 	"food-order-tracking/internal/models"
@@ -29,6 +31,33 @@ func GetOrders(c *gin.Context) {
 		var o models.Order
 		if err := rows.Scan(&o.ID, &o.CustomerID, &o.DeliveryAddress, &o.Status, &o.TotalAmount, &o.Notes, &o.CreatedAt, &o.UpdatedAt, &o.CustomerName, &o.CustomerPhone); err == nil {
 			orders = append(orders, o)
+		}
+	}
+
+	// Get order items for each order
+	for i := range orders {
+		itemRows, err := database.DB.Query(`
+			SELECT oi.quantity, i.name
+			FROM order_items oi
+			JOIN items i ON oi.item_id = i.id
+			WHERE oi.order_id = $1
+		`, orders[i].ID)
+		if err != nil {
+			continue
+		}
+
+		var items []string
+		for itemRows.Next() {
+			var qty int
+			var name string
+			if err := itemRows.Scan(&qty, &name); err == nil {
+				items = append(items, fmt.Sprintf("%dx %s", qty, name))
+			}
+		}
+		itemRows.Close()
+
+		if len(items) > 0 {
+			orders[i].Items = strings.Join(items, ", ")
 		}
 	}
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -32,6 +32,7 @@ type Order struct {
 	Status          string       `json:"status"`
 	TotalAmount     float64      `json:"total_amount"`
 	Notes          string       `json:"notes"`
+	Items          string       `json:"items"`
 	OrderItems     []OrderItem  `json:"order_items"`
 	CreatedAt      time.Time    `json:"created_at"`
 	UpdatedAt      time.Time    `json:"updated_at"`


### PR DESCRIPTION
Fixes issue #19

## Overview
The Orders page was showing "N/A" for items because the backend GetOrders function wasn't including order items in the response.

## Changes
- Updated GetOrders handler to join with order_items table
- Added Items field to Order model
- Orders now display items like "2x Pizza, 1x Salad" instead of N/A

## Files Changed
- internal/handlers/order.go
- internal/models/models.go

Closes #19