### PR TITLE
Fix issue 25: Order edit page shows original item quantities

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -229,7 +229,11 @@ func UpdateOrder(c *gin.Context) {
 				continue
 			}
 			var unitPrice float64
-			tx.QueryRow("SELECT price FROM items WHERE id = $1", item.ItemID).Scan(&unitPrice)
+			err = tx.QueryRow("SELECT price FROM items WHERE id = $1", item.ItemID).Scan(&unitPrice)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID: " + strconv.Itoa(item.ItemID)})
+				return
+			}
 			subtotal := unitPrice * float64(item.Quantity)
 
 			_, err = tx.Exec(`

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5,6 +5,11 @@ import OrderEdit from './pages/OrderEdit'
 import Customers from './pages/Customers'
 import Items from './pages/Items'
 
+function OrderEditWrapper() {
+  const location = useLocation()
+  return <OrderEdit key={location.pathname} />
+}
+
 function Navbar() {
   const location = useLocation()
   
@@ -42,7 +47,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/items" element={<Items />} />
           <Route path="/orders" element={<Orders />} />
-          <Route path="/orders/:id/edit" element={<OrderEdit />} />
+          <Route path="/orders/:id/edit" element={<OrderEditWrapper />} />
           <Route path="/customers" element={<Customers />} />
         </Routes>
       </main>

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -4,6 +4,7 @@ async function request(endpoint, options = {}) {
   const config = {
     headers: {
       'Content-Type': 'application/json',
+      'Cache-Control': 'no-cache',
       ...options.headers,
     },
     ...options,
@@ -13,7 +14,12 @@ async function request(endpoint, options = {}) {
     config.body = JSON.stringify(config.body);
   }
 
-  const response = await fetch(`${API_BASE}${endpoint}`, config);
+  const method = config.method || 'GET';
+  const url = method === 'GET' 
+    ? `${API_BASE}${endpoint}?t=${Date.now()}` 
+    : `${API_BASE}${endpoint}`;
+  
+  const response = await fetch(url, config);
   
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Request failed' }));


### PR DESCRIPTION
## Summary
- Prevents browser caching of GET API requests by adding Cache-Control header and timestamp query param
- Forces OrderEdit component to remount when navigating back to edit page to fetch fresh data
- Fixes error handling in UpdateOrder backend function

Fixes #25