### PR TITLE
Fix issue 30: Fix JSON unmarshal error when changing order status

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -280,7 +280,13 @@ function Orders() {
                 value={order.status}
                 onChange={async (e) => {
                   try {
-                    await api.updateOrder(order.id, { ...order, status: e.target.value });
+                    await api.updateOrder(order.id, {
+                      customer_id: order.customer_id,
+                      delivery_address: order.delivery_address,
+                      status: e.target.value,
+                      total_amount: order.total_amount,
+                      notes: order.notes
+                    });
                     loadData();
                   } catch (err) {
                     alert(err.message);


### PR DESCRIPTION
## Summary
- Only send required fields (customer_id, delivery_address, status, total_amount, notes) when updating order status
- Prevents spreading entire order object which includes order_items array
- Removes mismatch between backend's expected 'items' field and frontend's 'order_items' field
- Resolves the json: cannot unmarshal string into Go struct error

Fixes #30