### PR TITLE
Fix: Preserve scheduled_date when updating order status

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -220,7 +220,8 @@ function Orders() {
                       status: e.target.value,
                       total_amount: order.total_amount,
                       notes: order.notes,
-                      payment_method: order.payment_method
+                      payment_method: order.payment_method,
+                      scheduled_date: order.scheduled_date
                     });
                     loadData();
                   } catch (err) {


### PR DESCRIPTION
## Summary
Fixes the issue where scheduled_date is lost when updating an order's status through the quick status selector in the Orders page.

## Root Cause
The status change handler in Orders.jsx was constructing an update payload without the `scheduled_date` field. When this incomplete payload is sent to the backend, the database receives NULL for that field, overwriting the scheduled date.

## The Fix
Added `scheduled_date: order.scheduled_date` to the update payload in the status dropdown's onChange handler (Orders.jsx line 224).

## Impact
- Users can now safely update order status without losing scheduling information
- The scheduled_date is preserved for all status changes
- No backend changes needed - the backend handler was already working correctly

## Related Issue
Closes #54

## Testing
- ✅ Update order status from pending to preparing
- ✅ Verify scheduled_date remains in the database
- ✅ Check Orders page still displays the scheduled date
- ✅ OrderEdit page continues to work correctly