### PR TITLE
feat: Display schedule_date in PST timezone on frontend

### DIFF
--- a/web/src/pages/Items.jsx
+++ b/web/src/pages/Items.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { api } from '../services/api';
+import { formatDateInPST } from '../utils/dateUtils';
 
 function Items() {
   const [items, setItems] = useState([]);

--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
+import { formatDateInPST } from '../utils/dateUtils';
 
 function OrderEdit() {
   // Get order ID from URL params
@@ -65,7 +66,7 @@ function OrderEdit() {
         delivery_address: orderData.delivery_address || '',
         notes: orderData.notes || '',
         payment_method: orderData.payment_method || 'cash',
-        scheduled_date: orderData.scheduled_date ? orderData.scheduled_date.slice(0, 16) : ''
+        scheduled_date: orderData.scheduled_date ? formatDateInPST(orderData.scheduled_date, 'datetime-local') : ''
       });
       
       // Convert order items array to object for easy quantity management

--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../services/api';
+import { formatDateInPST } from '../utils/dateUtils';
 
 function Orders() {
   const [orders, setOrders] = useState([]);
@@ -200,9 +201,9 @@ function Orders() {
                <p><strong>Total:</strong> ${order.total_amount}</p>
                <p><strong>Payment Method:</strong> {order.payment_method === 'e-transfer' ? 'e-Transfer' : 'Cash'}</p>
                {order.notes && <p><strong>Notes:</strong> {order.notes}</p>}
-                {order.scheduled_date && (
-                  <p><strong>Scheduled:</strong> {new Date(order.scheduled_date).toLocaleString('en-US')}</p>
-                )}
+                 {order.scheduled_date && (
+                   <p><strong>Scheduled (PST):</strong> {formatDateInPST(order.scheduled_date, 'full')}</p>
+                 )}
                <p><strong>Created:</strong> {new Date(order.created_at).toLocaleString('en-US')}</p>
                {order.updated_at && order.updated_at !== order.created_at && (
                <p><strong>Updated:</strong> {new Date(order.updated_at).toLocaleString('en-US')}</p>

--- a/web/src/pages/Schedule.jsx
+++ b/web/src/pages/Schedule.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../services/api';
+import { getOrderDateStatus, formatDateInPST } from '../utils/dateUtils';
 
 function Schedule() {
   const [orders, setOrders] = useState([]);
@@ -34,10 +35,16 @@ function Schedule() {
     orders.forEach(order => {
       if (!order.scheduled_date) return;
       
+      // Convert to PST timezone for grouping
       const scheduledDate = new Date(order.scheduled_date);
-      scheduledDate.setHours(0, 0, 0, 0);
+      const pstDateStr = scheduledDate.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
+      const scheduledDatePST = new Date(pstDateStr);
+      scheduledDatePST.setHours(0, 0, 0, 0);
       
-      const diffDays = Math.floor((scheduledDate - today) / (1000 * 60 * 60 * 24));
+      const todayPST = new Date(today.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
+      todayPST.setHours(0, 0, 0, 0);
+      
+      const diffDays = Math.floor((scheduledDatePST - todayPST) / (1000 * 60 * 60 * 24));
       
       let label;
       if (diffDays < 0) {
@@ -49,7 +56,7 @@ function Schedule() {
       } else if (diffDays <= 7) {
         label = 'This Week';
       } else {
-        label = scheduledDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+        label = scheduledDatePST.toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles', weekday: 'short', month: 'short', day: 'numeric' });
       }
 
       if (!groups[label]) {

--- a/web/src/utils/dateUtils.js
+++ b/web/src/utils/dateUtils.js
@@ -1,0 +1,86 @@
+/**
+ * Format a UTC date to PST (Pacific Standard Time) timezone
+ * @param {string|Date} dateString - ISO date string or Date object
+ * @param {string} format - 'full' (date + time) or 'date' (date only)
+ * @returns {string} Formatted date in PST timezone
+ */
+export const formatDateInPST = (dateString, format = 'full') => {
+  if (!dateString) return '';
+  
+  try {
+    const date = new Date(dateString);
+    
+    if (format === 'full') {
+      // Display full date and time in PST
+      return date.toLocaleString('en-US', {
+        timeZone: 'America/Los_Angeles',
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: true
+      });
+    } else if (format === 'date') {
+      // Display date only in PST
+      return date.toLocaleDateString('en-US', {
+        timeZone: 'America/Los_Angeles',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+      });
+    } else if (format === 'datetime-local') {
+      // Convert to datetime-local format for input fields (YYYY-MM-DDTHH:mm)
+      const pstDate = new Date(date.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
+      const year = pstDate.getFullYear();
+      const month = String(pstDate.getMonth() + 1).padStart(2, '0');
+      const day = String(pstDate.getDate()).padStart(2, '0');
+      const hours = String(pstDate.getHours()).padStart(2, '0');
+      const minutes = String(pstDate.getMinutes()).padStart(2, '0');
+      return `${year}-${month}-${day}T${hours}:${minutes}`;
+    }
+  } catch (error) {
+    console.error('Error formatting date:', error);
+    return '';
+  }
+};
+
+/**
+ * Get the date status for scheduling (Today, Tomorrow, This Week, Overdue)
+ * @param {string|Date} dateString - ISO date string or Date object
+ * @returns {string} Status string
+ */
+export const getOrderDateStatus = (dateString) => {
+  if (!dateString) return '';
+  
+  try {
+    const scheduledDate = new Date(dateString);
+    const today = new Date();
+    
+    // Normalize times to compare dates only (in PST)
+    const scheduledDatePST = new Date(scheduledDate.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
+    const todayPST = new Date(today.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }));
+    
+    scheduledDatePST.setHours(0, 0, 0, 0);
+    todayPST.setHours(0, 0, 0, 0);
+    
+    const timeDiff = scheduledDatePST - todayPST;
+    const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
+    
+    if (daysDiff < 0) {
+      return 'overdue';
+    } else if (daysDiff === 0) {
+      return 'today';
+    } else if (daysDiff === 1) {
+      return 'tomorrow';
+    } else if (daysDiff <= 7) {
+      return 'this-week';
+    } else {
+      return 'future';
+    }
+  } catch (error) {
+    console.error('Error calculating date status:', error);
+    return '';
+  }
+};


### PR DESCRIPTION
## Summary
Implements proper PST (Pacific Standard Time) timezone display for all scheduled dates across the frontend while maintaining UTC storage in the database.

## Changes
**New File: web/src/utils/dateUtils.js**
- `formatDateInPST()` - Converts UTC dates to PST with multiple format options:
  - 'full': Date + time (e.g., "3/6/2026, 2:30:00 PM PST")
  - 'date': Date only (e.g., "Mar 6, 2026")
  - 'datetime-local': Input field format (e.g., "2026-03-06T14:30")
- `getOrderDateStatus()` - Determines order status relative to today in PST timezone:
  - 'overdue', 'today', 'tomorrow', 'this-week', 'future'

**Updated Files:**
- **Orders.jsx** - Display scheduled dates in PST with full format
- **OrderEdit.jsx** - Load/display scheduled dates in PST datetime-local format
- **Schedule.jsx** - Group orders by date using PST timezone for accurate categorization
- **Items.jsx** - Add dateUtils import for consistency

## Key Features
- ✅ All scheduled dates display in PST timezone
- ✅ Accurate date grouping (Today, Tomorrow, This Week, Overdue)
- ✅ DateTime input fields maintain PST time when editing
- ✅ Backend continues storing dates in UTC
- ✅ No impact on API or database structure

## Related Issue
Closes #56

## Testing
- ✅ View scheduled orders in Orders page - shows PST time
- ✅ Edit order and verify scheduled date loads in PST
- ✅ View Schedule page - dates grouped correctly by PST timezone
- ✅ Create order with scheduled date - time preserved correctly