### PR TITLE
fix: Add PST timezone label to scheduled_date display

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -200,9 +200,9 @@ function Orders() {
                <p><strong>Total:</strong> ${order.total_amount}</p>
                <p><strong>Payment Method:</strong> {order.payment_method === 'e-transfer' ? 'e-Transfer' : 'Cash'}</p>
                {order.notes && <p><strong>Notes:</strong> {order.notes}</p>}
-                {order.scheduled_date && (
-                  <p><strong>Scheduled:</strong> {new Date(order.scheduled_date).toLocaleString('en-US')}</p>
-                )}
+                 {order.scheduled_date && (
+                   <p><strong>Scheduled (PST):</strong> {new Date(order.scheduled_date).toLocaleString('en-US')}</p>
+                 )}
                <p><strong>Created:</strong> {new Date(order.created_at).toLocaleString('en-US')}</p>
                {order.updated_at && order.updated_at !== order.created_at && (
                <p><strong>Updated:</strong> {new Date(order.updated_at).toLocaleString('en-US')}</p>


### PR DESCRIPTION
## Summary
Since the backend is already converting scheduled_date to PST, just add a clear label to the frontend display to indicate the timezone.

## Changes
- **Orders.jsx**: Add "(PST)" label next to scheduled_date display to clarify the timezone

## Related Issue
Closes #56

## Testing
- ✅ Scheduled date displays with PST label in Orders page