### PR TITLE
fix: Store scheduled_date as pure UTC timestamp without timezone offset

### DIFF
--- a/TIMEZONE.md
+++ b/TIMEZONE.md
@@ -11,13 +11,14 @@ All timestamps in the application are stored and processed in **UTC (Coordinated
 ### Column Definition
 The `scheduled_date` column in the `orders` table is defined as:
 ```sql
-scheduled_date TIMESTAMP WITH TIME ZONE
+scheduled_date TIMESTAMP
 ```
 
-Using `TIMESTAMP WITH TIME ZONE` (also known as `TIMESTAMPTZ`) ensures that:
-- Timezone information is explicitly stored with the timestamp
-- PostgreSQL automatically converts to UTC for storage
-- PostgreSQL handles timezone-aware operations correctly
+Using `TIMESTAMP` (without timezone) ensures that:
+- All times are stored in UTC format without timezone offset
+- Consistent storage format: `2026-03-06 21:19:40.268226`
+- No timezone offset information is stored with the timestamp
+- The application always treats stored times as UTC
 
 ### Default Timezone
 All system timestamps use UTC:

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -25,7 +25,7 @@ func Migrate() error {
 			created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
 			updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
 		)`,
-	`CREATE TABLE IF NOT EXISTS orders (
+		`CREATE TABLE IF NOT EXISTS orders (
 		id SERIAL PRIMARY KEY,
 		customer_id INTEGER REFERENCES customers(id) ON DELETE SET NULL,
 		delivery_address TEXT NOT NULL,
@@ -33,7 +33,7 @@ func Migrate() error {
 		total_amount DECIMAL(10,2) NOT NULL,
 		notes TEXT,
 		payment_method VARCHAR(50) DEFAULT 'cash',
-		scheduled_date TIMESTAMP WITH TIME ZONE,
+		scheduled_date TIMESTAMP,
 		created_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
 		updated_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
 	)`,
@@ -67,9 +67,9 @@ func Migrate() error {
 		BEFORE UPDATE ON items
 		FOR EACH ROW
 		EXECUTE FUNCTION update_updated_at_column()`,
-		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS scheduled_date TIMESTAMP WITH TIME ZONE`,
+		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS scheduled_date TIMESTAMP`,
 		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS payment_method VARCHAR(50) DEFAULT 'cash'`,
-		`ALTER TABLE orders ALTER COLUMN scheduled_date TYPE TIMESTAMP WITH TIME ZONE`,
+		`ALTER TABLE orders ALTER COLUMN scheduled_date TYPE TIMESTAMP`,
 		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS payment_method VARCHAR(50) DEFAULT 'cash'`,
 	}
 


### PR DESCRIPTION
## Summary
Change the scheduled_date column type from TIMESTAMP WITH TIME ZONE to TIMESTAMP to ensure dates are stored in pure UTC format without timezone offset information.

## Problem
Previously, scheduled_date was using TIMESTAMP WITH TIME ZONE which stores the timezone offset with the value:
- Stored as: `2026-03-07 04:00:00-08`
- Frontend receives: Time with offset, causing confusion about actual UTC time
- Display becomes inconsistent across timezones

## Solution
Change to TIMESTAMP which stores pure UTC without offset:
- Now stored as: `2026-03-06 21:19:40.268226`
- Frontend receives: Pure UTC time that can be converted to PST for display
- Consistent storage and display across all timezones

## Changes
- **internal/database/migrate.go**: Change TIMESTAMP WITH TIME ZONE → TIMESTAMP for scheduled_date column
- **TIMEZONE.md**: Update documentation to reflect pure UTC storage

## Impact
- ✅ Scheduled dates now stored in consistent UTC format
- ✅ Simplifies frontend timezone conversions
- ✅ Existing data will be automatically converted during migration

## Related Issue
Closes #56

## Testing
- ✅ Create order with scheduled_date
- ✅ Verify database stores pure UTC: `2026-03-06 21:19:40.268226`
- ✅ Verify no `-08` or timezone offset in stored value