### PR TITLE
Fix Issue #78: Standardize Order model to use OrderItems array

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -1,11 +1,9 @@
 package handlers
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"food-order-tracking/internal/database"
@@ -100,7 +98,7 @@ func GetScheduledOrders(c *gin.Context) {
 	// Get order items for each order
 	for i := range orders {
 		itemRows, err := database.DB.Query(`
-			SELECT oi.quantity, i.name
+			SELECT oi.id, oi.order_id, oi.item_id, i.name, oi.quantity, oi.unit_price, oi.subtotal
 			FROM order_items oi
 			JOIN items i ON oi.item_id = i.id
 			WHERE oi.order_id = $1
@@ -109,19 +107,16 @@ func GetScheduledOrders(c *gin.Context) {
 			continue
 		}
 
-		var items []string
+		var orderItems []models.OrderItem
 		for itemRows.Next() {
-			var qty int
-			var name string
-			if err := itemRows.Scan(&qty, &name); err == nil {
-				items = append(items, fmt.Sprintf("%dx %s", qty, name))
+			var oi models.OrderItem
+			if err := itemRows.Scan(&oi.ID, &oi.OrderID, &oi.ItemID, &oi.ItemName, &oi.Quantity, &oi.UnitPrice, &oi.Subtotal); err == nil {
+				orderItems = append(orderItems, oi)
 			}
 		}
 		itemRows.Close()
 
-		if len(items) > 0 {
-			orders[i].Items = strings.Join(items, ", ")
-		}
+		orders[i].OrderItems = orderItems
 	}
 
 	c.JSON(http.StatusOK, orders)
@@ -160,7 +155,7 @@ func GetOrdersByCustomer(c *gin.Context) {
 	// Get order items for each order
 	for i := range orders {
 		itemRows, err := database.DB.Query(`
-			SELECT oi.quantity, i.name
+			SELECT oi.id, oi.order_id, oi.item_id, i.name, oi.quantity, oi.unit_price, oi.subtotal
 			FROM order_items oi
 			JOIN items i ON oi.item_id = i.id
 			WHERE oi.order_id = $1
@@ -169,19 +164,16 @@ func GetOrdersByCustomer(c *gin.Context) {
 			continue
 		}
 
-		var items []string
+		var orderItems []models.OrderItem
 		for itemRows.Next() {
-			var qty int
-			var name string
-			if err := itemRows.Scan(&qty, &name); err == nil {
-				items = append(items, fmt.Sprintf("%dx %s", qty, name))
+			var oi models.OrderItem
+			if err := itemRows.Scan(&oi.ID, &oi.OrderID, &oi.ItemID, &oi.ItemName, &oi.Quantity, &oi.UnitPrice, &oi.Subtotal); err == nil {
+				orderItems = append(orderItems, oi)
 			}
 		}
 		itemRows.Close()
 
-		if len(items) > 0 {
-			orders[i].Items = strings.Join(items, ", ")
-		}
+		orders[i].OrderItems = orderItems
 	}
 
 	c.JSON(http.StatusOK, orders)
@@ -353,7 +345,7 @@ func UpdateOrder(c *gin.Context) {
 	if scheduledDateUTC != nil {
 		*scheduledDateUTC = scheduledDateUTC.UTC()
 	}
-	
+
 	_, err = tx.Exec(`
 		UPDATE orders SET customer_id = $1, delivery_address = $2, status = $3, total_amount = $4, notes = $5, payment_method = $6, scheduled_date = $7, updated_at = CURRENT_TIMESTAMP
 		WHERE id = $8

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -24,28 +24,27 @@ type Item struct {
 }
 
 type Order struct {
-	ID              int          `json:"id"`
-	CustomerID      int          `json:"customer_id"`
-	CustomerName    string       `json:"customer_name"`
-	CustomerPhone   string       `json:"customer_phone"`
-	DeliveryAddress string       `json:"delivery_address"`
-	Status          string       `json:"status"`
-	TotalAmount     float64      `json:"total_amount"`
-	Notes           string       `json:"notes"`
-	PaymentMethod   string       `json:"payment_method"`
-	Items           string       `json:"items"`
-	OrderItems      []OrderItem  `json:"order_items"`
-	ScheduledDate   *time.Time   `json:"scheduled_date"`
-	CreatedAt       time.Time    `json:"created_at"`
-	UpdatedAt       time.Time    `json:"updated_at"`
+	ID              int         `json:"id"`
+	CustomerID      int         `json:"customer_id"`
+	CustomerName    string      `json:"customer_name"`
+	CustomerPhone   string      `json:"customer_phone"`
+	DeliveryAddress string      `json:"delivery_address"`
+	Status          string      `json:"status"`
+	TotalAmount     float64     `json:"total_amount"`
+	Notes           string      `json:"notes"`
+	PaymentMethod   string      `json:"payment_method"`
+	OrderItems      []OrderItem `json:"order_items"`
+	ScheduledDate   *time.Time  `json:"scheduled_date"`
+	CreatedAt       time.Time   `json:"created_at"`
+	UpdatedAt       time.Time   `json:"updated_at"`
 }
 
 type OrderItem struct {
-	ID         int     `json:"id"`
-	OrderID    int     `json:"order_id"`
-	ItemID     int     `json:"item_id"`
-	ItemName   string  `json:"item_name"`
-	Quantity   int     `json:"quantity"`
-	UnitPrice  float64 `json:"unit_price"`
-	Subtotal   float64 `json:"subtotal"`
+	ID        int     `json:"id"`
+	OrderID   int     `json:"order_id"`
+	ItemID    int     `json:"item_id"`
+	ItemName  string  `json:"item_name"`
+	Quantity  int     `json:"quantity"`
+	UnitPrice float64 `json:"unit_price"`
+	Subtotal  float64 `json:"subtotal"`
 }

--- a/web/src/pages/Items.jsx
+++ b/web/src/pages/Items.jsx
@@ -375,7 +375,9 @@ function Items() {
                     </span>
                   </div>
                   <div className="history-order-items">
-                    {order.items || 'No items'}
+                    {order.order_items && order.order_items.length > 0 
+                      ? order.order_items.map(item => `${item.quantity}x ${item.item_name}`).join(', ')
+                      : 'No items'}
                   </div>
                   <div className="history-order-footer">
                     <span className="order-total">${order.total_amount.toFixed(2)}</span>

--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -331,8 +331,10 @@ function OrderEdit() {
                       <span className="order-id">Order #{order.id}</span>
                       <span className={`status-badge status-${order.status}`}>{order.status}</span>
                     </div>
-                    {order.items && (
-                      <div className="history-order-items">{order.items}</div>
+                    {order.order_items && order.order_items.length > 0 && (
+                      <div className="history-order-items">
+                        {order.order_items.map(item => `${item.quantity}x ${item.item_name}`).join(', ')}
+                      </div>
                     )}
                     <div className="history-order-details">
                       <span>{new Date(order.created_at).toLocaleDateString()}</span>

--- a/web/src/pages/Schedule.jsx
+++ b/web/src/pages/Schedule.jsx
@@ -136,7 +136,9 @@ function Schedule() {
                       {order.customer_name || 'No customer'}
                     </div>
                     <div className="schedule-order-items">
-                      {order.items || 'No items'}
+                      {order.order_items && order.order_items.length > 0 
+                        ? order.order_items.map(item => `${item.quantity}x ${item.item_name}`).join(', ')
+                        : 'No items'}
                     </div>
                     <div className="schedule-order-footer">
                       <span className="order-total">${order.total_amount}</span>


### PR DESCRIPTION
## Summary
This PR fixes Issue #78: Order model has confusing dual structure for items by standardizing all order endpoints to return the `order_items` array instead of having both `items` (string) and `order_items` (array) fields.

## Changes

### Backend
1. **Order Model** (`internal/models/models.go`)
   - Removed duplicate `Items` string field
   - Now only uses `OrderItems` []OrderItem array

2. **Order Handlers** (`internal/handlers/order.go`)
   - Updated `GetScheduledOrders` to return `OrderItems` array instead of string
   - Updated `GetOrdersByCustomer` to return `OrderItems` array instead of string
   - Removed unused imports (fmt, strings)

### Frontend
1. **Schedule.jsx** - Updated to use `order.order_items` array
2. **Items.jsx** - Updated to use `order.order_items` array  
3. **OrderEdit.jsx** - Updated to use `order.order_items` array

## Why This Fix

**Before:**
- GetOrders: returned `order_items` array ✅
- GetOrder: returned `order_items` array ✅
- GetScheduledOrders: returned `items` string ❌
- GetOrdersByCustomer: returned `items` string ❌

**After:**
- All endpoints return consistent `order_items` array ✅
- Frontend converts array to display string where needed

## API Consistency

Now all order endpoints return the same structure:
```json
{
  "id": 1,
  "customer_id": 1,
  "order_items": [
    {
      "id": 1,
      "order_id": 1,
      "item_id": 1,
      "item_name": "Pizza",
      "quantity": 2,
      "unit_price": 12.99,
      "subtotal": 25.98
    }
  ]
}
```

## Testing
- ✅ Go backend builds successfully
- ✅ React frontend builds successfully
- ✅ All order endpoints now return consistent structure

## Related Issues
- Fixes #78