### PR TITLE
Fix Issue #77: Fix indentation error in Orders.jsx

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -90,7 +90,7 @@ function Orders() {
       delivery_address: order.delivery_address || '',
       total_amount: String(order.total_amount) || '',
       notes: order.notes,
-                       payment_method: order.payment_method || '',
+      payment_method: order.payment_method || '',
       scheduled_date: order.scheduled_date ? order.scheduled_date.split('T')[0] : ''
     });
     setEditingId(order.id);


### PR DESCRIPTION
## Summary
Fixed indentation error in Orders.jsx where the `payment_method` line had extra indentation (11 spaces instead of 6) in the setFormData call within the handleEdit function.

## Changes
- Fixed indentation in `web/src/pages/Orders.jsx` line 93
- Changed from 11 spaces to 6 spaces for consistency

## Before
```javascript
notes: order.notes,
                 payment_method: order.payment_method || '',
```

## After
```javascript
notes: order.notes,
payment_method: order.payment_method || '',
```

## Testing
- ✅ Frontend builds successfully

## Related
- Fixes #77