### PR TITLE
Fix Issue #75: Add validation for order item quantities

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -258,6 +258,10 @@ func CreateOrder(c *gin.Context) {
 
 	var totalAmount float64
 	for _, item := range input.Items {
+		if item.Quantity <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Quantity must be greater than 0"})
+			return
+		}
 		var price float64
 		err := tx.QueryRow("SELECT price FROM items WHERE id = $1", item.ItemID).Scan(&price)
 		if err != nil {
@@ -367,7 +371,8 @@ func UpdateOrder(c *gin.Context) {
 		// Insert new order items
 		for _, item := range input.Items {
 			if item.Quantity <= 0 {
-				continue
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Quantity must be greater than 0"})
+				return
 			}
 			var unitPrice float64
 			err = tx.QueryRow("SELECT price FROM items WHERE id = $1", item.ItemID).Scan(&unitPrice)


### PR DESCRIPTION
## Summary
Added server-side validation to ensure order item quantities are positive numbers, preventing negative quantities from being stored in the database.

## Changes

### `internal/handlers/order.go`

1. **CreateOrder** - Added validation before processing items:
   ```go
   if item.Quantity <= 0 {
       c.JSON(http.StatusBadRequest, gin.H{"error": "Quantity must be greater than 0"})
       return
   }
   ```

2. **UpdateOrder** - Changed from silently skipping to returning error:
   ```go
   // Before: just continued (skipped negative quantities)
   // After: returns 400 error
   if item.Quantity <= 0 {
       c.JSON(http.StatusBadRequest, gin.H{"error": "Quantity must be greater than 0"})
       return
   }
   ```

## Impact
- Prevents negative quantities in database
- Ensures correct total calculations
- Maintains data integrity
- Both create and update operations are protected

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #75