### PR TITLE
Fix Issue #64: Load customers for Orders page dropdown

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -41,8 +41,12 @@ function Orders() {
   const loadData = async () => {
     try {
       setLoading(true);
-      const ordersData = await api.getOrders();
+      const [ordersData, customersData] = await Promise.all([
+        api.getOrders(),
+        api.getCustomers()
+      ]);
       setOrders(ordersData);
+      setCustomers(customersData);
     } catch (err) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
Fixed the Orders page so that customers are loaded and available in the dropdown when creating a new order.

## Changes
`web/src/pages/Orders.jsx` - Updated loadData function to fetch customers alongside orders using Promise.all for parallel loading.

## Before
```javascript
const loadData = async () => {
  try {
    setLoading(true);
    const ordersData = await api.getOrders();
    setOrders(ordersData);
    // customers never loaded!
  } catch (err) {
    ...
  }
};
```

## After
```javascript
const loadData = async () => {
  try {
    setLoading(true);
    const [ordersData, customersData] = await Promise.all([
      api.getOrders(),
      api.getCustomers()
    ]);
    setOrders(ordersData);
    setCustomers(customersData);
  } catch (err) {
    ...
  }
};
```

## Impact
- Users can now select a customer when creating a new order
- Customer dropdown is populated with all existing customers
- Uses Promise.all for efficient parallel loading

## Testing
- ✅ Frontend builds successfully

## Related
- Fixes #64