### PR TITLE
Fix Issue #65: Add scheduled_date to GetOrdersByCustomer query

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -130,7 +130,7 @@ func GetOrdersByCustomer(c *gin.Context) {
 	}
 
 	rows, err := database.DB.Query(`
-		SELECT o.id, o.customer_id, o.delivery_address, o.status, o.total_amount, o.notes, o.payment_method, o.created_at, o.updated_at,
+		SELECT o.id, o.customer_id, o.delivery_address, o.status, o.total_amount, o.notes, o.payment_method, o.scheduled_date, o.created_at, o.updated_at,
 		       COALESCE(c.name, ''), COALESCE(c.phone, '')
 		FROM orders o
 		LEFT JOIN customers c ON o.customer_id = c.id
@@ -147,7 +147,7 @@ func GetOrdersByCustomer(c *gin.Context) {
 	var orders []models.Order
 	for rows.Next() {
 		var o models.Order
-		if err := rows.Scan(&o.ID, &o.CustomerID, &o.DeliveryAddress, &o.Status, &o.TotalAmount, &o.Notes, &o.PaymentMethod, &o.CreatedAt, &o.UpdatedAt, &o.CustomerName, &o.CustomerPhone); err == nil {
+		if err := rows.Scan(&o.ID, &o.CustomerID, &o.DeliveryAddress, &o.Status, &o.TotalAmount, &o.Notes, &o.PaymentMethod, &o.ScheduledDate, &o.CreatedAt, &o.UpdatedAt, &o.CustomerName, &o.CustomerPhone); err == nil {
 			orders = append(orders, o)
 		}
 	}


### PR DESCRIPTION
## Summary
Fixed the GetOrdersByCustomer handler to include `scheduled_date` in the SELECT query and Scan operation.

## Changes
`internal/handlers/order.go` - Added `o.scheduled_date` to the SELECT query and corresponding Scan parameter.

## Before
```go
SELECT o.id, o.customer_id, o.delivery_address, o.status, o.total_amount, o.notes, o.payment_method, o.created_at, o.updated_at...
```

## After
```go
SELECT o.id, o.customer_id, o.delivery_address, o.status, o.total_amount, o.notes, o.payment_method, o.scheduled_date, o.created_at, o.updated_at...
```

## Impact
- Customer order history now includes scheduled_date
- Consistent data with other order endpoints
- Prevents scan errors

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #65