### PR TITLE
Fix Issue #66: Allow delivery_address to be NULL

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -69,6 +69,7 @@ func Migrate() error {
 		EXECUTE FUNCTION update_updated_at_column()`,
 		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS scheduled_date TIMESTAMP`,
 		`ALTER TABLE orders ADD COLUMN IF NOT EXISTS payment_method VARCHAR(50) DEFAULT 'cash'`,
+		`ALTER TABLE orders ALTER COLUMN delivery_address DROP NOT NULL`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary
Fixed the database schema to allow NULL values for the delivery_address field in the orders table.

## Changes
`internal/database/migrate.go` - Added migration to drop NOT NULL constraint:
```go
ALTER TABLE orders ALTER COLUMN delivery_address DROP NOT NULL
```

## Impact
- Orders can now be created without a delivery address
- Frontend forms work correctly without causing database errors
- Existing orders with delivery addresses remain unaffected

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #66