### PR TITLE
Fix Issue #67: Validate at least one item is required for orders

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -256,6 +256,11 @@ func CreateOrder(c *gin.Context) {
 	}
 	defer tx.Rollback()
 
+	if len(input.Items) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "At least one item is required"})
+		return
+	}
+
 	var totalAmount float64
 	for _, item := range input.Items {
 		if item.Quantity <= 0 {


### PR DESCRIPTION
## Summary
Added validation in CreateOrder handler to ensure at least one item is provided before creating an order.

## Changes
`internal/handlers/order.go` - Added validation before processing items:
```go
if len(input.Items) == 0 {
    c.JSON(http.StatusBadRequest, gin.H{"error": "At least one item is required"})
    return
}
```

## Impact
- Prevents creation of invalid $0 orders
- Maintains data integrity
- Clear error message for users

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #67