### PR TITLE
Fix Issue #68: Add validation for order status values

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -249,6 +249,15 @@ func CreateOrder(c *gin.Context) {
 		input.PaymentMethod = "cash"
 	}
 
+	validStatuses := map[string]bool{
+		"pending": true, "preparing": true, "ready": true,
+		"delivered": true, "cancelled": true,
+	}
+	if input.Status != "" && !validStatuses[input.Status] {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid status"})
+		return
+	}
+
 	tx, err := database.DB.Begin()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -339,6 +348,15 @@ func UpdateOrder(c *gin.Context) {
 
 	if input.PaymentMethod == "" {
 		input.PaymentMethod = "cash"
+	}
+
+	validStatuses := map[string]bool{
+		"pending": true, "preparing": true, "ready": true,
+		"delivered": true, "cancelled": true,
+	}
+	if input.Status != "" && !validStatuses[input.Status] {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid status"})
+		return
 	}
 
 	tx, err := database.DB.Begin()


### PR DESCRIPTION
## Summary
Added validation in both CreateOrder and UpdateOrder handlers to ensure the status field contains a valid status value.

## Changes
`internal/handlers/order.go` - Added validation in both handlers:
```go
validStatuses := map[string]bool{
    "pending": true, "preparing": true, "ready": true,
    "delivered": true, "cancelled": true,
}
if input.Status != "" && !validStatuses[input.Status] {
    c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid status"})
    return
}
```

## Impact
- Prevents invalid status values in database
- Maintains data consistency
- Clear error message for invalid status

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #68