### PR TITLE
Fix Issue #69: Add friendly error when deleting customer with orders

### DIFF
--- a/internal/handlers/customer.go
+++ b/internal/handlers/customer.go
@@ -106,6 +106,17 @@ func DeleteCustomer(c *gin.Context) {
 		return
 	}
 
+	var orderCount int
+	err = database.DB.QueryRow("SELECT COUNT(*) FROM orders WHERE customer_id = $1", id).Scan(&orderCount)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if orderCount > 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot delete customer with existing orders"})
+		return
+	}
+
 	_, err = database.DB.Exec("DELETE FROM customers WHERE id = $1", id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})


### PR DESCRIPTION
## Summary
Added validation in DeleteCustomer handler to check for existing orders before deletion and return a user-friendly error message.

## Changes
`internal/handlers/customer.go` - Added check before deletion:
```go
var orderCount int
err = database.DB.QueryRow("SELECT COUNT(*) FROM orders WHERE customer_id = $1", id).Scan(&orderCount)
if err != nil {
    return
}
if orderCount > 0 {
    c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot delete customer with existing orders"})
    return
}
```

## Impact
- Users get clear error message when trying to delete customer with orders
- No more confusing database constraint errors
- Better user experience

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #69