### PR TITLE
Fix Issue #72: Rename DeleteItem to DeactivateItem

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,7 +85,7 @@ func main() {
 			items.GET("/:id", handlers.GetItem)
 			items.POST("", handlers.CreateItem)
 			items.PUT("/:id", handlers.UpdateItem)
-			items.DELETE("/:id", handlers.DeleteItem)
+			items.DELETE("/:id", handlers.DeactivateItem)
 		}
 
 		orders := api.Group("/orders")

--- a/internal/handlers/item.go
+++ b/internal/handlers/item.go
@@ -109,7 +109,7 @@ func UpdateItem(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Item updated"})
 }
 
-func DeleteItem(c *gin.Context) {
+func DeactivateItem(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})


### PR DESCRIPTION
## Summary
Renamed the handler function from `DeleteItem` to `DeactivateItem` to better reflect its soft-delete behavior.

## Changes
1. `internal/handlers/item.go` - Renamed function from DeleteItem to DeactivateItem
2. `cmd/main.go` - Updated route to use handlers.DeactivateItem

## Impact
- Function name now accurately describes its behavior
- API consumers will better understand the function does a soft-delete
- Message already said "Item deactivated" - now function name matches

## Testing
- ✅ Go backend builds successfully

## Related
- Fixes #72