### PR TITLE
Fix Issue #73: Fix parseInt(id) being called multiple times

### DIFF
--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -95,8 +95,9 @@ function OrderEdit() {
       // Load customer's order history if customer is assigned
       if (orderData.customer_id) {
         try {
+          const orderId = parseInt(id);
           const orders = await api.getOrdersByCustomer(orderData.customer_id);
-          setCustomerOrders(orders.filter(o => o.id !== parseInt(id)));
+          setCustomerOrders(orders.filter(o => o.id !== orderId && !isNaN(orderId)));
           setShowOrderHistory(true);
         } catch (err) {
           console.error('Error fetching customer orders:', err);
@@ -143,8 +144,9 @@ function OrderEdit() {
     // Fetch customer's order history
     if (customerId) {
       try {
+        const orderId = parseInt(id);
         const orders = await api.getOrdersByCustomer(customerId);
-        setCustomerOrders(orders.filter(o => o.id !== parseInt(id) || isNaN(parseInt(id))));
+        setCustomerOrders(orders.filter(o => o.id !== orderId && !isNaN(orderId)));
         setShowOrderHistory(true);
       } catch (err) {
         console.error('Error fetching customer orders:', err);


### PR DESCRIPTION
## Summary
Fixed the parseInt(id) being called multiple times in OrderEdit.jsx by parsing it once and reusing the value.

## Changes
`web/src/pages/OrderEdit.jsx` - Fixed two locations (lines 99 and 147):
- Before: `parseInt(id)` called multiple times
- After: Parse once and use consistently

## Before
```javascript
setCustomerOrders(orders.filter(o => o.id !== parseInt(id) || isNaN(parseInt(id))));
```

## After
```javascript
const orderId = parseInt(id);
setCustomerOrders(orders.filter(o => o.id !== orderId && !isNaN(orderId)));
```

## Impact
- Cleaner code
- Avoids potential NaN issues
- More readable logic

## Testing
- ✅ Frontend builds successfully

## Related
- Fixes #73