### PR TITLE
Fix #98: Fix NaN in orderId filter in OrderEdit.jsx

### DIFF
--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -95,9 +95,10 @@ function OrderEdit() {
       // Load customer's order history if customer is assigned
       if (orderData.customer_id) {
         try {
-          const orderId = parseInt(id);
+          const parsedOrderId = parseInt(id);
+          const orderId = isNaN(parsedOrderId) ? null : parsedOrderId;
           const orders = await api.getOrdersByCustomer(orderData.customer_id);
-          setCustomerOrders(orders.filter(o => o.id !== orderId && !isNaN(orderId)));
+          setCustomerOrders(orders.filter(o => orderId === null || o.id !== orderId));
           setShowOrderHistory(true);
         } catch (err) {
           console.error('Error fetching customer orders:', err);


### PR DESCRIPTION
## Summary
- Fixes Issue #98
- Validate orderId before using it in the filter to prevent incorrect filtering logic

## Changes
- In web/src/pages/OrderEdit.jsx lines 98-100: Added validation to check if parsed orderId is NaN, and handle it gracefully by setting orderId to null and filtering out the current order only when orderId is valid