### PR TITLE
Fix #99: Fix NaN when parsing total_amount in Orders.jsx

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -57,10 +57,15 @@ function Orders() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      const amount = parseFloat(formData.total_amount);
+      if (isNaN(amount) || amount <= 0) {
+        alert('Please enter a valid total amount');
+        return;
+      }
       const data = {
         ...formData,
         customer_id: parseInt(formData.customer_id) || null,
-        total_amount: parseFloat(formData.total_amount),
+        total_amount: amount,
         status: 'pending',
         scheduled_date: formData.scheduled_date ? formData.scheduled_date + ':00Z' : null
       };


### PR DESCRIPTION
## Summary
- Fixes Issue #99
- Validate total_amount before sending to backend to prevent NaN values

## Changes
- In web/src/pages/Orders.jsx: Added validation to check if parsed total_amount is NaN or <= 0, shows alert if invalid