### PR TITLE
Fix #101: Delete order_items when order is deleted

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -437,11 +437,26 @@ func DeleteOrder(c *gin.Context) {
 		return
 	}
 
-	_, err = database.DB.Exec("DELETE FROM orders WHERE id = $1", id)
+	tx, err := database.DB.Begin()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec("DELETE FROM order_items WHERE order_id = $1", id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	_, err = tx.Exec("DELETE FROM orders WHERE id = $1", id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	tx.Commit()
 
 	c.JSON(http.StatusOK, gin.H{"message": "Order deleted"})
 }


### PR DESCRIPTION
## Summary
- Fixes Issue #101
- Delete order_items before deleting the order to prevent orphaned records

## Changes
- In internal/handlers/order.go: Modified DeleteOrder to use a transaction that first deletes order_items, then deletes the order