### PR TITLE
Fix #112: Add null check for created_at in Orders.jsx

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -282,15 +282,15 @@ function Orders() {
                             )}
                           </div>
                            <p><strong>Total:</strong> ${order.total_amount}</p>
-                           <p><strong>Payment Method:</strong> {order.payment_method === 'e-transfer' ? 'e-Transfer' : 'Cash'}</p>
-                           {order.notes && <p><strong>Notes:</strong> {order.notes}</p>}
-                            {order.scheduled_date && (
-                              <p><strong>Scheduled:</strong> {new Date(order.scheduled_date).toLocaleString('en-US')}</p>
+                            <p><strong>Payment Method:</strong> {order.payment_method === 'e-transfer' ? 'e-Transfer' : 'Cash'}</p>
+                            {order.notes && <p><strong>Notes:</strong> {order.notes}</p>}
+                             {order.scheduled_date && (
+                               <p><strong>Scheduled:</strong> {new Date(order.scheduled_date).toLocaleString('en-US')}</p>
+                             )}
+                            {order.created_at && <p><strong>Created:</strong> {new Date(order.created_at).toLocaleString('en-US')}</p>}
+                            {order.updated_at && order.updated_at !== order.created_at && (
+                            <p><strong>Updated:</strong> {new Date(order.updated_at).toLocaleString('en-US')}</p>
                             )}
-                           <p><strong>Created:</strong> {new Date(order.created_at).toLocaleString('en-US')}</p>
-                           {order.updated_at && order.updated_at !== order.created_at && (
-                           <p><strong>Updated:</strong> {new Date(order.updated_at).toLocaleString('en-US')}</p>
-                           )}
                         </div>
                         <div className="card-actions">
                           <Link to={`/orders/${order.id}/edit`} className="btn-primary">Edit</Link>


### PR DESCRIPTION
## Summary
- Fixes Issue #112
- Add null check for created_at before calling new Date() to prevent Invalid Date

## Changes
- In web/src/pages/Orders.jsx: Added conditional check to only display created_at if it exists