### PR TITLE
Fix #113: Add null check for created_at in OrderEdit.jsx

### DIFF
--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -339,8 +339,8 @@ function OrderEdit() {
                       </div>
                     )}
                     <div className="history-order-details">
-                      <span>{new Date(order.created_at).toLocaleDateString()}</span>
-                      <span className="order-total">${order.total_amount}</span>
+                      <span>{order.created_at ? new Date(order.created_at).toLocaleDateString() : 'N/A'}</span>
+                      <span className="order-total">${order.total_amount ? order.total_amount.toFixed(2) : '0.00'}</span>
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- Fixes Issue #113
- Add null check for created_at and total_amount to prevent runtime errors

## Changes
- In web/src/pages/OrderEdit.jsx: Added conditional checks for created_at (shows N/A if null) and total_amount (shows 0.00 if null)