### PR TITLE
Fix #114: Add customer validation to UpdateOrder

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -368,6 +368,15 @@ func UpdateOrder(c *gin.Context) {
 		return
 	}
 
+	if input.CustomerID > 0 {
+		var exists bool
+		err := database.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM customers WHERE id = $1)", input.CustomerID).Scan(&exists)
+		if err != nil || !exists {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Customer not found"})
+			return
+		}
+	}
+
 	tx, err := database.DB.Begin()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})


### PR DESCRIPTION
## Summary
- Fixes Issue #114
- Add customer validation to UpdateOrder to match CreateOrder behavior

## Changes
- In internal/handlers/order.go: Added validation to check if customer exists when CustomerID > 0 in UpdateOrder
- Note: Customer is optional (ID=0 allows anonymous orders), but when a customer ID is provided, it must exist in the database