### PR TITLE
Fix #107: Add logging for scan errors in GetOrder

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -52,6 +52,8 @@ func GetOrders(c *gin.Context) {
 			var oi models.OrderItem
 			if err := itemRows.Scan(&oi.ID, &oi.OrderID, &oi.ItemID, &oi.ItemName, &oi.Quantity, &oi.UnitPrice, &oi.Subtotal); err == nil {
 				orderItems = append(orderItems, oi)
+			} else {
+				log.Printf("Error scanning order item for order %d: %v", orders[i].ID, err)
 			}
 		}
 		itemRows.Close()
@@ -112,6 +114,8 @@ func GetScheduledOrders(c *gin.Context) {
 			var oi models.OrderItem
 			if err := itemRows.Scan(&oi.ID, &oi.OrderID, &oi.ItemID, &oi.ItemName, &oi.Quantity, &oi.UnitPrice, &oi.Subtotal); err == nil {
 				orderItems = append(orderItems, oi)
+			} else {
+				log.Printf("Error scanning order item for scheduled order: %v", err)
 			}
 		}
 		itemRows.Close()
@@ -169,6 +173,8 @@ func GetOrdersByCustomer(c *gin.Context) {
 			var oi models.OrderItem
 			if err := itemRows.Scan(&oi.ID, &oi.OrderID, &oi.ItemID, &oi.ItemName, &oi.Quantity, &oi.UnitPrice, &oi.Subtotal); err == nil {
 				orderItems = append(orderItems, oi)
+			} else {
+				log.Printf("Error scanning order item for customer order: %v", err)
 			}
 		}
 		itemRows.Close()
@@ -216,6 +222,8 @@ func GetOrder(c *gin.Context) {
 		var oi models.OrderItem
 		if err := itemRows.Scan(&oi.ID, &oi.OrderID, &oi.ItemID, &oi.ItemName, &oi.Quantity, &oi.UnitPrice, &oi.Subtotal); err == nil {
 			orderItems = append(orderItems, oi)
+		} else {
+			log.Printf("Error scanning order item: %v", err)
 		}
 	}
 	o.OrderItems = orderItems


### PR DESCRIPTION
## Summary
- Fixes Issue #107
- Add logging when scan errors occur in order item queries

## Changes
- In internal/handlers/order.go: Added log.Printf statements when scan errors occur in GetOrder, GetOrders, GetScheduledOrders, and GetOrdersByCustomer to help with debugging instead of silently ignoring errors