### PR TITLE
Fix #102: Add logging for scan errors in GetOrders

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -31,6 +31,8 @@ func GetOrders(c *gin.Context) {
 		var o models.Order
 		if err := rows.Scan(&o.ID, &o.CustomerID, &o.DeliveryAddress, &o.Status, &o.TotalAmount, &o.Notes, &o.PaymentMethod, &o.ScheduledDate, &o.CreatedAt, &o.UpdatedAt, &o.CustomerName, &o.CustomerPhone); err == nil {
 			orders = append(orders, o)
+		} else {
+			log.Printf("Error scanning order: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes Issue #102
- Add logging when scan errors occur in GetOrders

## Changes
- In internal/handlers/order.go: Added log.Printf when scan errors occur to help with debugging instead of silently ignoring errors