### PR TITLE
Fix #104: Add logging for scan errors in GetItems

### DIFF
--- a/internal/handlers/item.go
+++ b/internal/handlers/item.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"net/http"
 	"strconv"
 
@@ -26,6 +27,8 @@ func GetItems(c *gin.Context) {
 		var i models.Item
 		if err := rows.Scan(&i.ID, &i.Name, &i.Description, &i.Price, &i.Category, &i.Available, &i.CreatedAt, &i.UpdatedAt); err == nil {
 			items = append(items, i)
+		} else {
+			log.Printf("Error scanning item: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes Issue #104
- Add logging when scan errors occur in GetItems

## Changes
- In internal/handlers/item.go: Added log.Printf when scan errors occur to help with debugging instead of silently ignoring errors