### PR TITLE
Fix dependency review to only run on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,10 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
-  # Dependency Review - runs always
+  # Dependency Review - runs on PRs only
   dependency-review:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Summary
Fix the dependency-review-action to only run on pull requests.

## Problem
The GitHub Actions dependency review was failing with:
> Both a base ref and head ref must be provided

This is because the action requires `base_ref`/`head_ref` which are only available on pull requests.

## Solution
Add `if: github.event_name == 'pull_request'` condition to the dependency-review job.