### PR TITLE
Fix CI path filtering for backend, frontend, and lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,8 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.modified, '.go') ||
-      contains(github.event.head_commit.modified, 'go.mod') ||
-      contains(github.event.head_commit.modified, 'go.sum') ||
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && (contains(github.event.head_commit.modified, '.go') || contains(github.event.head_commit.modified, 'go.mod') || contains(github.event.head_commit.modified, 'go.sum')))
     steps:
       - uses: actions/checkout@v4
 
@@ -42,8 +40,8 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.modified, 'web/') ||
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && contains(github.event.head_commit.modified, 'web/'))
     defaults:
       run:
         working-directory: web
@@ -67,10 +65,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.modified, '.go') ||
-      contains(github.event.head_commit.modified, 'go.mod') ||
-      contains(github.event.head_commit.modified, 'go.sum') ||
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && (contains(github.event.head_commit.modified, '.go') || contains(github.event.head_commit.modified, 'go.mod') || contains(github.event.head_commit.modified, 'go.sum')))
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Fix CI jobs to only run when relevant files are modified.

## Problem
Backend, frontend, and lint jobs were running even when no Go or web files were modified on push to main.

## Solution
Updated the `if` conditions to:
- Always run on pull requests
- Only run on push to main when relevant files are modified:
  - Backend: `.go`, `go.mod`, `go.sum`
  - Frontend: `web/`
  - Lint: `.go`, `go.mod`, `go.sum`