### PR TITLE
Change database volume to bind mount

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - /opt/food-order-tracking/data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -56,9 +56,6 @@ services:
     networks:
       - food-order-network
     restart: unless-stopped
-
-volumes:
-  postgres_data:
 
 networks:
   food-order-network:


### PR DESCRIPTION
## Summary
Change PostgreSQL data storage from named Docker volume to bind mount at `/opt/food-order-tracking/data`

## Why
- Named volumes are stored in Docker's internal storage and deleted with `docker-compose down -v`
- Bind mount stores data on host filesystem, surviving container removal
- Better for production deployment on Raspberry Pi

## Changes
- Changed volume from `postgres_data:/var/lib/postgresql/data` to `/opt/food-order-tracking/data:/var/lib/postgresql/data`
- Removed named volume definition from compose file

## Setup Required
On the server/Pi, create the directory with correct permissions:
```bash
sudo mkdir -p /opt/food-order-tracking/data
sudo chown -R 999:999 /opt/food-order-tracking/data  # PostgreSQL runs as user 999
```