### PR TITLE
Fix: Docker build always runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,10 @@ jobs:
       - uses: actions/dependency-review-action@v4
 
   # Build and push Docker images - only on push to main (not PRs)
+  # Runs independently so it always builds regardless of which files changed
   docker:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [backend, frontend]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem
The Docker build job was skipping because it depends on `backend` and `frontend` jobs, which only run when Go or web files are modified. When workflow files or docs were changed, those jobs were skipped, causing the docker job to also skip.

## Solution
Removed the `needs: [backend, frontend]` dependency from the docker job so it runs independently and always builds images on push to main, regardless of which files were changed.

## Before
- backend/frontend jobs only run on Go/web file changes
- docker job depends on backend/frontend
- Result: docker job skipped when only workflow/docs changed

## After
- docker job runs independently on every push to main
- ARMv7 images will always be built for Pi deployment