### PR TITLE
Fix nginx.conf path in Dockerfile.frontend

### DIFF
--- a/deployment/Dockerfile.frontend
+++ b/deployment/Dockerfile.frontend
@@ -21,7 +21,7 @@ RUN npm run build
 FROM nginx:alpine
 
 # Copy nginx config
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY deployment/nginx.conf /etc/nginx/nginx.conf
 
 # Copy built files
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
Fix the nginx.conf copy path in Dockerfile.frontend to work with the CI build context.

## Problem
The Dockerfile had:
```dockerfile
COPY nginx.conf /etc/nginx/nginx.conf
```

But the CI build context is the project root (`.`), and nginx.conf was moved to the `deployment/` folder. This caused the Docker build to fail with "file not found".

## Solution
Updated the path to:
```dockerfile
COPY deployment/nginx.conf /etc/nginx/nginx.conf
```

This ensures the frontend Docker image builds correctly in CI.