### PR TITLE
feat: customer page revamp with warm editorial design

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1860,3 +1860,414 @@ body {
 @media (max-width: 420px) {
   .home-nav { grid-template-columns: 1fr; }
 }
+
+/* Customer Page - Warm editorial design */
+.cst-root {
+  min-height: 100vh;
+  background: var(--cream);
+  color: var(--espresso);
+  font-family: var(--font-body);
+  padding: 36px 40px 80px;
+}
+
+/* Header */
+.cst-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-bottom: 20px;
+  border-bottom: 2px solid var(--espresso);
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.cst-title {
+  font-family: var(--font-display);
+  font-size: 38px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  line-height: 1;
+}
+.cst-title em { font-style: italic; color: var(--amber); }
+.cst-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 6px;
+  letter-spacing: 0.3px;
+}
+.cst-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+/* Buttons */
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--espresso); color: var(--cream);
+  border: none; border-radius: 6px;
+  padding: 9px 18px;
+  font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: opacity 0.15s;
+  text-decoration: none;
+}
+.btn-primary:hover { opacity: 0.78; }
+
+.btn-ghost {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: none; color: var(--muted);
+  border: 1.5px solid var(--rule); border-radius: 6px;
+  padding: 8px 16px;
+  font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: border-color 0.15s, color 0.15s;
+}
+.btn-ghost:hover { border-color: var(--brown); color: var(--brown); }
+
+.btn-danger {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: none; color: var(--red);
+  border: 1.5px solid rgba(160,43,43,0.3); border-radius: 6px;
+  padding: 7px 13px;
+  font-family: var(--font-mono); font-size: 11px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: background 0.15s, border-color 0.15s;
+}
+.btn-danger:hover { background: var(--red-bg); border-color: var(--red); }
+
+/* Search bar */
+.cst-search-wrap {
+  position: relative;
+  margin-bottom: 24px;
+}
+.cst-search-icon {
+  position: absolute;
+  left: 14px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  pointer-events: none;
+}
+.cst-search {
+  width: 100%; max-width: 400px;
+  background: white;
+  border: 1.5px solid var(--rule);
+  border-radius: 7px;
+  padding: 10px 14px 10px 38px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--espresso);
+  outline: none;
+  transition: border-color 0.15s;
+}
+.cst-search::placeholder { color: var(--muted); }
+.cst-search:focus { border-color: var(--amber); }
+
+/* Slide-down form panel */
+.cst-form-wrap {
+  overflow: hidden;
+  transition: max-height 0.35s cubic-bezier(0.4,0,0.2,1),
+              opacity 0.25s ease,
+              margin-bottom 0.35s ease;
+}
+.cst-form-wrap.open {
+  max-height: 600px;
+  opacity: 1;
+  margin-bottom: 28px;
+}
+.cst-form-wrap.closed {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+}
+
+.cst-form {
+  background: white;
+  border: 1.5px solid var(--rule);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.cst-form-head {
+  padding: 16px 22px 14px;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.cst-form-title {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 600;
+}
+.cst-form-title em { font-style: italic; color: var(--amber); }
+
+.cst-form-body {
+  padding: 22px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.cst-form-body .full { grid-column: 1 / -1; }
+
+.cst-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.cst-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+}
+.cst-input {
+  background: var(--cream);
+  border: 1.5px solid var(--rule);
+  border-radius: 6px;
+  padding: 9px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--espresso);
+  outline: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+.cst-input::placeholder { color: var(--muted); font-weight: 300; }
+.cst-input:focus { border-color: var(--amber); background: white; }
+
+.cst-form-actions {
+  padding: 14px 22px 18px;
+  display: flex;
+  gap: 10px;
+  border-top: 1px solid var(--rule);
+  background: var(--cream);
+}
+
+/* Error banner */
+.cst-form-error {
+  margin: 0 22px 14px;
+  padding: 10px 14px;
+  background: var(--red-bg);
+  border: 1px solid rgba(160,43,43,0.25);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--red);
+}
+
+/* Grid */
+.cst-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 14px;
+}
+
+.cst-card {
+  background: white;
+  border: 1.5px solid var(--rule);
+  border-radius: var(--radius);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.18s, border-color 0.18s, transform 0.18s;
+  opacity: 0;
+  animation: fadeUp 0.4s ease forwards;
+}
+.cst-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--cream-3);
+  transform: translateY(-2px);
+}
+
+.cst-card-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px 18px 14px;
+}
+
+.cst-avatar {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  background: var(--cream-2);
+  border: 2px solid var(--rule);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--brown);
+  flex-shrink: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+.cst-card:hover .cst-avatar {
+  background: var(--amber-bg);
+  border-color: var(--amber-lt);
+}
+
+.cst-card-info { flex: 1; min-width: 0; }
+.cst-name {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--espresso);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cst-id {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+  margin-top: 3px;
+  letter-spacing: 0.3px;
+}
+
+.cst-card-body {
+  padding: 0 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  flex: 1;
+}
+.cst-detail {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+.cst-detail-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--muted);
+  flex-shrink: 0;
+  width: 52px;
+}
+.cst-detail-value {
+  color: var(--brown);
+  font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 13px;
+}
+.cst-detail-value.na { color: var(--rule); font-style: italic; }
+
+.cst-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 18px 13px;
+  border-top: 1px solid var(--rule);
+  background: var(--cream);
+}
+.cst-since {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: 0.3px;
+}
+.cst-card-actions { display: flex; gap: 8px; }
+
+/* Empty */
+.cst-empty {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 80px 20px; gap: 12px; text-align: center;
+}
+.cst-empty-title {
+  font-family: var(--font-display);
+  font-style: italic; font-size: 22px; color: var(--muted);
+}
+.cst-empty-sub {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--rule); letter-spacing: 0.5px;
+}
+
+/* Load / Error */
+.cst-load {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 60vh; gap: 16px;
+}
+.cst-spinner {
+  width: 28px; height: 28px;
+  border: 2px solid var(--cream-3);
+  border-top-color: var(--amber);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+.cst-load-text {
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--muted); letter-spacing: 0.5px;
+}
+.cst-error {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 60vh; gap: 12px;
+}
+.cst-error-msg {
+  font-family: var(--font-mono); font-size: 13px; color: var(--red);
+}
+.cst-retry {
+  background: var(--espresso); color: var(--cream);
+  border: none; border-radius: 6px;
+  padding: 8px 20px;
+  font-family: var(--font-mono); font-size: 12px; cursor: pointer;
+}
+
+/* Confirm dialog */
+.cst-overlay {
+  position: fixed; inset: 0;
+  background: rgba(26,15,10,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 100;
+  animation: fadeIn 0.15s ease;
+}
+.cst-dialog {
+  background: white;
+  border: 1.5px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 28px 28px 22px;
+  max-width: 360px; width: 90%;
+  box-shadow: var(--shadow-md);
+  animation: scaleIn 0.18s ease;
+}
+.cst-dialog-title {
+  font-family: var(--font-display);
+  font-size: 20px; font-weight: 600;
+  margin-bottom: 8px;
+}
+.cst-dialog-body {
+  font-size: 13px; color: var(--muted);
+  line-height: 1.6; margin-bottom: 22px;
+  font-weight: 300;
+}
+.cst-dialog-actions { display: flex; gap: 10px; justify-content: flex-end; }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 700px) {
+  .cst-root { padding: 20px 16px 60px; }
+  .cst-header { flex-direction: column; align-items: flex-start; }
+  .cst-title { font-size: 30px; }
+  .cst-form-body { grid-template-columns: 1fr; }
+  .cst-form-body .full { grid-column: 1; }
+}

--- a/web/src/pages/Customers.jsx
+++ b/web/src/pages/Customers.jsx
@@ -1,174 +1,348 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../services/api';
+import '../index.css';
 
-function Customers() {
-  const [customers, setCustomers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState(null);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [formData, setFormData] = useState({
-    name: '',
-    phone: '',
-    email: '',
-    address: ''
+/* ─── Helpers ────────────────────────────── */
+
+const EMPTY_FORM = { name: '', phone: '', email: '', address: '' };
+
+function fmtDate(iso) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    timeZone: 'America/Los_Angeles',
   });
+}
 
-  useEffect(() => {
-    loadCustomers();
-  }, []);
+function initials(name) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join('');
+}
 
-  const loadCustomers = async () => {
+/* ─── ConfirmDialog ──────────────────────── */
+
+function ConfirmDialog({ name, onConfirm, onCancel }) {
+  return (
+    <div className="cst-overlay" onClick={onCancel}>
+      <div className="cst-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="cst-dialog-title">Delete customer?</div>
+        <div className="cst-dialog-body">
+          <strong>{name}</strong> and all associated data will be permanently removed.
+          This cannot be undone.
+        </div>
+        <div className="cst-dialog-actions">
+          <button className="btn-ghost" onClick={onCancel}>Cancel</button>
+          <button className="btn-primary" style={{ background: 'var(--red)' }} onClick={onConfirm}>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── CustomerCard ───────────────────────── */
+
+function CustomerCard({ customer, onEdit, onDelete, delay }) {
+  return (
+    <div className="cst-card" style={{ animationDelay: `${delay}ms` }}>
+      <div className="cst-card-top">
+        <div className="cst-avatar">{initials(customer.name)}</div>
+        <div className="cst-card-info">
+          <div className="cst-name">{customer.name}</div>
+          <div className="cst-id">ID #{customer.id}</div>
+        </div>
+      </div>
+
+      <div className="cst-card-body">
+        {[
+          { label: 'Phone',   value: customer.phone },
+          { label: 'Email',   value: customer.email },
+          { label: 'Address', value: customer.address },
+        ].map(({ label, value }) => (
+          <div key={label} className="cst-detail">
+            <span className="cst-detail-label">{label}</span>
+            <span className={`cst-detail-value${!value ? ' na' : ''}`}>
+              {value || 'N/A'}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="cst-card-footer">
+        <span className="cst-since">Since {fmtDate(customer.created_at)}</span>
+        <div className="cst-card-actions">
+          <button className="btn-ghost" style={{ padding: '6px 12px', fontSize: '11px' }}
+            onClick={() => onEdit(customer)}>
+            Edit
+          </button>
+          <button className="btn-danger" onClick={() => onDelete(customer)}>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Customers ──────────────────────────── */
+
+export default function Customers() {
+  const [customers, setCustomers]   = useState([]);
+  const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState(null);
+  const [formOpen, setFormOpen]     = useState(false);
+  const [editingId, setEditingId]   = useState(null);
+  const [formData, setFormData]     = useState(EMPTY_FORM);
+  const [formError, setFormError]   = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [search, setSearch]         = useState('');
+  const [deleteTarget, setDeleteTarget] = useState(null); // { id, name }
+  const searchRef = useRef(null);
+
+  const load = useCallback(async () => {
     try {
       setLoading(true);
+      setError(null);
       const data = await api.getCustomers();
-      setCustomers(data);
+      setCustomers(data || []);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  /* Form */
+  const openCreate = () => {
+    setFormData(EMPTY_FORM);
+    setEditingId(null);
+    setFormError(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (customer) => {
+    setFormData({
+      name:    customer.name    || '',
+      phone:   customer.phone   || '',
+      email:   customer.email   || '',
+      address: customer.address || '',
+    });
+    setEditingId(customer.id);
+    setFormError(null);
+    setFormOpen(true);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const closeForm = () => {
+    setFormOpen(false);
+    setEditingId(null);
+    setFormData(EMPTY_FORM);
+    setFormError(null);
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setSubmitting(true);
+    setFormError(null);
     try {
       if (editingId) {
         await api.updateCustomer(editingId, formData);
       } else {
         await api.createCustomer(formData);
       }
-      setShowForm(false);
-      setEditingId(null);
-      setFormData({ name: '', phone: '', email: '', address: '' });
-      loadCustomers();
+      closeForm();
+      load();
     } catch (err) {
-      alert(err.message);
+      setFormError(err.message);
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  const handleEdit = (customer) => {
-    setFormData({
-      name: customer.name,
-      phone: customer.phone || '',
-      email: customer.email || '',
-      address: customer.address || ''
-    });
-    setEditingId(customer.id);
-    setShowForm(true);
-  };
-
-  const handleDelete = async (id) => {
-    if (!confirm('Delete this customer?')) return;
-    try {
-      await api.deleteCustomer(id);
-      loadCustomers();
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-
-  const handleCancel = () => {
-    setShowForm(false);
-    setEditingId(null);
-    setFormData({ name: '', phone: '', email: '', address: '' });
-  };
-
-  const filteredCustomers = customers.filter(customer => {
-    const search = searchTerm.toLowerCase();
-    return !searchTerm || 
-      customer.name?.toLowerCase().includes(search) ||
-      customer.email?.toLowerCase().includes(search) ||
-      customer.phone?.toLowerCase().includes(search);
+  const field = (key) => ({
+    value: formData[key],
+    onChange: (e) => setFormData((prev) => ({ ...prev, [key]: e.target.value })),
+    className: 'cst-input',
   });
 
-  if (loading) return <div className="loading">Loading customers...</div>;
-  if (error) return <div className="error">Error: {error}</div>;
+  /* Delete */
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await api.deleteCustomer(deleteTarget.id);
+      setDeleteTarget(null);
+      load();
+    } catch (err) {
+      setDeleteTarget(null);
+      setError(err.message);
+    }
+  };
 
+  /* Filter */
+  const filtered = customers.filter((c) => {
+    if (!search) return true;
+    const s = search.toLowerCase();
+    return (
+      c.name?.toLowerCase().includes(s) ||
+      c.email?.toLowerCase().includes(s) ||
+      c.phone?.toLowerCase().includes(s)
+    );
+  });
+
+  /* ── Render ── */
   return (
-    <div className="page">
-      <div className="page-header">
-        <h1>Customers</h1>
-        <button className="btn-primary" onClick={() => setShowForm(!showForm)}>
-          {showForm ? 'Cancel' : 'Add Customer'}
-        </button>
-      </div>
+    <>
+      <div className="cst-root">
 
-      <div className="filters">
-        <input
-          type="text"
-          placeholder="Search by name, email, or phone..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="search-input"
-        />
-      </div>
+        {/* Delete confirm */}
+        {deleteTarget && (
+          <ConfirmDialog
+            name={deleteTarget.name}
+            onConfirm={confirmDelete}
+            onCancel={() => setDeleteTarget(null)}
+          />
+        )}
 
-      {showForm && (
-        <form onSubmit={handleSubmit} className="form">
-          <h3>{editingId ? 'Edit Customer' : 'New Customer'}</h3>
-          <input
-            type="text"
-            placeholder="Name"
-            value={formData.name}
-            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            required
-          />
-          <input
-            type="text"
-            placeholder="Phone"
-            value={formData.phone}
-            onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-          />
-          <input
-            type="email"
-            placeholder="Email"
-            value={formData.email}
-            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-          />
-          <input
-            type="text"
-            placeholder="Address"
-            value={formData.address}
-            onChange={(e) => setFormData({ ...formData, address: e.target.value })}
-          />
-          <div className="form-actions">
-            <button type="submit" className="btn-primary">
-              {editingId ? 'Update' : 'Create'}
-            </button>
-            {editingId && (
-              <button type="button" className="btn-secondary" onClick={handleCancel}>
+        {/* Header */}
+        <div className="cst-header">
+          <div>
+            <h1 className="cst-title">Our <em>Customers</em></h1>
+            <div className="cst-meta">
+              {customers.length} customer{customers.length !== 1 ? 's' : ''}
+              {search && filtered.length !== customers.length && ` · ${filtered.length} shown`}
+            </div>
+          </div>
+          <div className="cst-header-actions">
+            {formOpen
+              ? <button className="btn-ghost" onClick={closeForm}>✕ Cancel</button>
+              : <button className="btn-primary" onClick={openCreate}>+ Add Customer</button>
+            }
+          </div>
+        </div>
+
+        {/* Slide-down form */}
+        <div className={`cst-form-wrap ${formOpen ? 'open' : 'closed'}`}>
+          <form className="cst-form" onSubmit={handleSubmit}>
+            <div className="cst-form-head">
+              <div className="cst-form-title">
+                {editingId ? <>Edit <em>customer</em></> : <>New <em>customer</em></>}
+              </div>
+            </div>
+
+            {formError && <div className="cst-form-error">{formError}</div>}
+
+            <div className="cst-form-body">
+              <div className="cst-field full">
+                <label className="cst-label">Name *</label>
+                <input {...field('name')} placeholder="Full name" required />
+              </div>
+              <div className="cst-field">
+                <label className="cst-label">Phone</label>
+                <input {...field('phone')} placeholder="e.g. 604-555-0100" />
+              </div>
+              <div className="cst-field">
+                <label className="cst-label">Email</label>
+                <input {...field('email')} type="email" placeholder="name@example.com" />
+              </div>
+              <div className="cst-field full">
+                <label className="cst-label">Address</label>
+                <input {...field('address')} placeholder="Delivery address" />
+              </div>
+            </div>
+
+            <div className="cst-form-actions">
+              <button type="submit" className="btn-primary" disabled={submitting}>
+                {submitting ? 'Saving…' : editingId ? 'Update customer' : 'Create customer'}
+              </button>
+              <button type="button" className="btn-ghost" onClick={closeForm}>
                 Cancel
               </button>
-            )}
-          </div>
-        </form>
-      )}
+            </div>
+          </form>
+        </div>
 
-      <div className="card-grid">
-        {filteredCustomers.map((customer) => (
-          <div key={customer.id} className="card">
-            <div className="card-header">
-              <h3>{customer.name}</h3>
-              <span className="customer-id">ID: {customer.id}</span>
-            </div>
-            <div className="card-body">
-              <p><strong>Phone:</strong> {customer.phone || 'N/A'}</p>
-              <p><strong>Email:</strong> {customer.email || 'N/A'}</p>
-              <p><strong>Address:</strong> {customer.address || 'N/A'}</p>
-              <p><strong>Created:</strong> {new Date(customer.created_at).toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles' })}</p>
-            </div>
-            <div className="card-actions">
-              <button className="btn-primary" onClick={() => handleEdit(customer)}>Edit</button>
-              <button className="btn-danger" onClick={() => handleDelete(customer.id)}>Delete</button>
-            </div>
+        {/* Loading */}
+        {loading && (
+          <div className="cst-load">
+            <div className="cst-spinner" />
+            <span className="cst-load-text">Loading customers…</span>
           </div>
-        ))}
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <div className="cst-error">
+            <p className="cst-error-msg">{error}</p>
+            <button className="cst-retry" onClick={load}>Try again</button>
+          </div>
+        )}
+
+        {/* Content */}
+        {!loading && !error && (
+          <>
+            {/* Search */}
+            <div className="cst-search-wrap">
+              <span className="cst-search-icon">
+                <SearchIcon />
+              </span>
+              <input
+                ref={searchRef}
+                className="cst-search"
+                type="text"
+                placeholder="Search by name, email or phone…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+
+            {/* Empty state */}
+            {customers.length === 0 && (
+              <div className="cst-empty">
+                <span style={{ fontSize: 32, opacity: 0.25 }}>✦</span>
+                <div className="cst-empty-title">No customers yet</div>
+                <div className="cst-empty-sub">Add your first customer to get started.</div>
+              </div>
+            )}
+
+            {/* No search results */}
+            {customers.length > 0 && filtered.length === 0 && (
+              <div className="cst-empty">
+                <div className="cst-empty-title">No results</div>
+                <div className="cst-empty-sub">Try a different name, email, or phone number.</div>
+              </div>
+            )}
+
+            {/* Grid */}
+            <div className="cst-grid">
+              {filtered.map((customer, i) => (
+                <CustomerCard
+                  key={customer.id}
+                  customer={customer}
+                  delay={i * 40}
+                  onEdit={openEdit}
+                  onDelete={(c) => setDeleteTarget({ id: c.id, name: c.name })}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
       </div>
-      {customers.length === 0 && <p className="empty">No customers yet</p>}
-    </div>
+    </>
   );
 }
 
-export default Customers;
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Complete Customer page revamp with warm editorial design (cream base, espresso text, amber accents)
- Extract Customer page CSS to centralized index.css using design tokens
- Add confirm dialog for delete functionality
- Add slide-down form panel for create/edit customer
- Improve customer cards with avatar initials and better layout
- Add search with icon, empty states, and loading/error states
- Use CSS animations (fadeUp, fadeIn, scaleIn, spin)
- Build passes successfully