### PR TITLE
feat: items page revamp with warm editorial design

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2271,3 +2271,564 @@ body {
   .cst-form-body { grid-template-columns: 1fr; }
   .cst-form-body .full { grid-column: 1; }
 }
+
+/* Items Page - Warm editorial design */
+.itm-root {
+  min-height: 100vh;
+  background: var(--cream);
+  color: var(--espresso);
+  font-family: var(--font-body);
+  padding: 36px 40px 80px;
+}
+
+/* Header */
+.itm-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-bottom: 20px;
+  border-bottom: 2px solid var(--espresso);
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.itm-title {
+  font-family: var(--font-display);
+  font-size: 38px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  line-height: 1;
+}
+.itm-title em { font-style: italic; color: var(--amber); }
+.itm-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 6px;
+  letter-spacing: 0.3px;
+}
+.itm-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+/* Buttons */
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--espresso); color: var(--cream);
+  border: none; border-radius: 6px;
+  padding: 9px 18px;
+  font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+.btn-primary:hover { opacity: 0.78; }
+.btn-primary:disabled { opacity: 0.35; cursor: not-allowed; }
+
+.btn-order {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--amber); color: white;
+  border: none; border-radius: 6px;
+  padding: 9px 18px;
+  font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+.btn-order:hover { opacity: 0.85; }
+.btn-order:disabled { opacity: 0.35; cursor: not-allowed; }
+
+.btn-ghost {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: none; color: var(--muted);
+  border: 1.5px solid var(--rule); border-radius: 6px;
+  padding: 8px 16px;
+  font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.btn-ghost:hover { border-color: var(--brown); color: var(--brown); }
+
+.btn-danger {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: none; color: var(--red);
+  border: 1.5px solid rgba(160,43,43,0.3); border-radius: 6px;
+  padding: 6px 12px;
+  font-family: var(--font-mono); font-size: 11px;
+  cursor: pointer; letter-spacing: 0.3px;
+  transition: background 0.15s, border-color 0.15s;
+}
+.btn-danger:hover { background: var(--red-bg); border-color: var(--red); }
+
+/* Filters bar */
+.itm-filters {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+.itm-search-wrap {
+  position: relative;
+  flex: 1; min-width: 200px; max-width: 340px;
+}
+.itm-search-icon {
+  position: absolute; left: 13px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted); pointer-events: none;
+}
+.itm-search {
+  width: 100%;
+  background: white; border: 1.5px solid var(--rule); border-radius: 7px;
+  padding: 9px 12px 9px 36px;
+  font-family: var(--font-mono); font-size: 12px; color: var(--espresso);
+  outline: none; transition: border-color 0.15s;
+}
+.itm-search::placeholder { color: var(--muted); }
+.itm-search:focus { border-color: var(--amber); }
+
+/* Category pill filters */
+.itm-cat-pills {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.itm-cat-pill {
+  background: white; border: 1.5px solid var(--rule); border-radius: 20px;
+  padding: 5px 13px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--muted);
+  cursor: pointer; letter-spacing: 0.3px; text-transform: capitalize;
+  transition: background 0.13s, border-color 0.13s, color 0.13s;
+  white-space: nowrap;
+}
+.itm-cat-pill:hover { border-color: var(--brown); color: var(--brown); }
+.itm-cat-pill.active {
+  background: var(--espresso); border-color: var(--espresso); color: var(--cream);
+}
+
+/* Slide-down panels */
+.itm-panel-wrap {
+  overflow: hidden;
+  transition: max-height 0.38s cubic-bezier(0.4,0,0.2,1),
+              opacity 0.25s ease,
+              margin-bottom 0.35s ease;
+}
+.itm-panel-wrap.open   { max-height: 900px; opacity: 1; margin-bottom: 28px; }
+.itm-panel-wrap.closed { max-height: 0; opacity: 0; margin-bottom: 0; }
+
+.itm-panel {
+  background: white;
+  border: 1.5px solid var(--rule);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.itm-panel-head {
+  padding: 16px 22px 14px;
+  border-bottom: 1px solid var(--rule);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.itm-panel-title {
+  font-family: var(--font-display);
+  font-size: 17px; font-weight: 600;
+}
+.itm-panel-title em { font-style: italic; color: var(--amber); }
+
+/* Item form body */
+.itm-form-body {
+  padding: 22px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.itm-form-body .full { grid-column: 1 / -1; }
+.itm-form-body .third { grid-column: span 1; }
+
+.itm-field { display: flex; flex-direction: column; gap: 5px; }
+.itm-label {
+  font-family: var(--font-mono);
+  font-size: 10px; text-transform: uppercase;
+  letter-spacing: 1px; color: var(--muted);
+}
+.itm-input {
+  background: var(--cream); border: 1.5px solid var(--rule); border-radius: 6px;
+  padding: 9px 12px;
+  font-family: var(--font-body); font-size: 13px; color: var(--espresso);
+  outline: none; transition: border-color 0.15s, background 0.15s;
+}
+.itm-input::placeholder { color: var(--muted); font-weight: 300; }
+.itm-input:focus { border-color: var(--amber); background: white; }
+
+.itm-select {
+  background: var(--cream); border: 1.5px solid var(--rule); border-radius: 6px;
+  padding: 9px 12px;
+  font-family: var(--font-mono); font-size: 12px; color: var(--espresso);
+  outline: none; cursor: pointer; transition: border-color 0.15s;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238a7060' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+.itm-select:focus { border-color: var(--amber); }
+
+.itm-form-actions {
+  padding: 14px 22px 18px;
+  display: flex; gap: 10px;
+  border-top: 1px solid var(--rule);
+  background: var(--cream);
+}
+.itm-form-error {
+  margin: 0 22px 14px;
+  padding: 10px 14px;
+  background: var(--red-bg);
+  border: 1px solid rgba(160,43,43,0.25);
+  border-radius: 6px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--red);
+}
+
+/* Order form layout */
+.ord-body {
+  padding: 22px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 22px;
+}
+.ord-col { display: flex; flex-direction: column; gap: 14px; }
+.ord-summary {
+  background: var(--cream);
+  border: 1.5px solid var(--rule);
+  border-radius: 8px;
+  padding: 16px;
+}
+.ord-summary-title {
+  font-family: var(--font-mono);
+  font-size: 10px; text-transform: uppercase;
+  letter-spacing: 1px; color: var(--muted);
+  margin-bottom: 12px;
+}
+.ord-summary-empty {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--rule);
+  font-style: italic; text-align: center;
+  padding: 12px 0;
+}
+.ord-line {
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 8px; padding: 5px 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 12px;
+}
+.ord-line:last-of-type { border-bottom: none; }
+.ord-line-name { color: var(--brown); }
+.ord-line-qty { font-family: var(--font-mono); font-size: 10px; color: var(--muted); }
+.ord-line-price { font-family: var(--font-mono); font-size: 12px; color: var(--espresso); }
+.ord-total {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding-top: 10px; margin-top: 4px;
+  border-top: 2px solid var(--espresso);
+}
+.ord-total-label {
+  font-family: var(--font-mono);
+  font-size: 10px; text-transform: uppercase;
+  letter-spacing: 1px; color: var(--muted);
+}
+.ord-total-value {
+  font-family: var(--font-display);
+  font-size: 22px; font-weight: 600;
+  color: var(--espresso);
+}
+
+/* Customer history panel */
+.ord-history {
+  background: var(--cream);
+  border: 1.5px solid var(--rule);
+  border-radius: 8px;
+  padding: 16px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+.ord-history-title {
+  font-family: var(--font-mono);
+  font-size: 10px; text-transform: uppercase;
+  letter-spacing: 1px; color: var(--muted);
+  margin-bottom: 12px;
+}
+.ord-hist-row {
+  display: flex; flex-direction: column; gap: 3px;
+  padding: 8px 0; border-bottom: 1px solid var(--rule);
+  font-size: 12px;
+}
+.ord-hist-row:last-child { border-bottom: none; }
+.ord-hist-top {
+  display: flex; justify-content: space-between;
+  align-items: baseline; gap: 8px;
+}
+.ord-hist-id {
+  font-family: var(--font-mono); font-size: 10px; color: var(--muted);
+}
+.ord-hist-date {
+  font-family: var(--font-mono); font-size: 10px; color: var(--muted);
+}
+.ord-hist-items {
+  color: var(--brown); font-size: 11px; line-height: 1.5;
+}
+.ord-hist-footer {
+  display: flex; justify-content: space-between; align-items: center;
+}
+.ord-hist-total {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  color: var(--espresso);
+}
+.ord-hist-status {
+  font-family: var(--font-mono); font-size: 10px;
+  text-transform: capitalize; color: var(--muted);
+  border: 1px solid var(--rule); border-radius: 10px;
+  padding: 2px 8px;
+}
+
+/* Category sections */
+.itm-category {
+  margin-bottom: 36px;
+  opacity: 0;
+  animation: fadeUp 0.4s ease forwards;
+}
+.itm-cat-head {
+  display: flex; align-items: baseline; gap: 10px;
+  padding-bottom: 10px; margin-bottom: 16px;
+  border-bottom: 1.5px solid var(--espresso);
+}
+.itm-cat-name {
+  font-family: var(--font-display);
+  font-size: 22px; font-weight: 600;
+  text-transform: capitalize;
+}
+.itm-cat-count {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--muted);
+}
+
+/* Item cards */
+.itm-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+}
+.itm-card {
+  background: white;
+  border: 1.5px solid var(--rule);
+  border-radius: var(--radius);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.18s, border-color 0.18s, transform 0.18s;
+  opacity: 0;
+  animation: fadeUp 0.4s ease forwards;
+}
+.itm-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--cream-3);
+  transform: translateY(-2px);
+}
+.itm-card.selected {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 3px rgba(196,124,43,0.12);
+}
+
+.itm-card-body {
+  padding: 16px 18px 12px; flex: 1;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.itm-card-top {
+  display: flex; justify-content: space-between;
+  align-items: flex-start; gap: 8px;
+}
+.itm-card-name {
+  font-family: var(--font-display);
+  font-size: 16px; font-weight: 600;
+  color: var(--espresso); line-height: 1.25;
+  flex: 1;
+}
+.itm-card-price {
+  font-family: var(--font-display);
+  font-size: 17px; font-weight: 600;
+  color: var(--amber); white-space: nowrap;
+  flex-shrink: 0;
+}
+.itm-card-desc {
+  font-size: 12px; color: var(--muted);
+  line-height: 1.55; font-weight: 300;
+}
+
+/* Qty selector */
+.itm-qty-row {
+  display: flex; align-items: center;
+  gap: 0;
+  border: 1.5px solid var(--rule);
+  border-radius: 7px; overflow: hidden;
+  background: var(--cream);
+  margin-top: 4px;
+  transition: border-color 0.15s;
+}
+.itm-card.selected .itm-qty-row { border-color: var(--amber); }
+.itm-qty-btn {
+  width: 36px; height: 36px;
+  background: none; border: none;
+  font-size: 18px; line-height: 1;
+  color: var(--brown); cursor: pointer;
+  transition: background 0.12s;
+  flex-shrink: 0;
+  font-family: var(--font-body);
+}
+.itm-qty-btn:hover { background: var(--cream-2); }
+.itm-qty-btn:active { background: var(--cream-3); }
+.itm-qty-input {
+  flex: 1; min-width: 0;
+  border: none; outline: none;
+  background: none;
+  text-align: center;
+  font-family: var(--font-mono); font-size: 13px;
+  color: var(--espresso);
+  padding: 0;
+}
+.itm-qty-input::-webkit-inner-spin-button,
+.itm-qty-input::-webkit-outer-spin-button { -webkit-appearance: none; }
+.itm-qty-input[type=number] { -moz-appearance: textfield; }
+
+.itm-card-footer {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 18px 12px;
+  border-top: 1px solid var(--rule);
+  background: var(--cream);
+  gap: 8px;
+}
+
+/* Empty / Load / Error */
+.itm-empty {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 60px 20px; gap: 12px; text-align: center;
+}
+.itm-empty-title {
+  font-family: var(--font-display);
+  font-style: italic; font-size: 22px; color: var(--muted);
+}
+.itm-empty-sub {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--rule); letter-spacing: 0.5px;
+}
+.itm-load {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 60vh; gap: 16px;
+}
+.itm-spinner {
+  width: 28px; height: 28px;
+  border: 2px solid var(--cream-3); border-top-color: var(--amber);
+  border-radius: 50%; animation: spin 0.8s linear infinite;
+}
+.itm-load-text {
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--muted); letter-spacing: 0.5px;
+}
+.itm-error {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 60vh; gap: 12px;
+}
+.itm-error-msg { font-family: var(--font-mono); font-size: 13px; color: var(--red); }
+.itm-retry {
+  background: var(--espresso); color: var(--cream);
+  border: none; border-radius: 6px; padding: 8px 20px;
+  font-family: var(--font-mono); font-size: 12px; cursor: pointer;
+}
+
+/* Confirm dialog */
+.itm-overlay {
+  position: fixed; inset: 0;
+  background: rgba(26,15,10,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 100; animation: fadeIn 0.15s ease;
+}
+.itm-dialog {
+  background: white; border: 1.5px solid var(--rule); border-radius: var(--radius);
+  padding: 28px 28px 22px; max-width: 360px; width: 90%;
+  box-shadow: var(--shadow-md); animation: scaleIn 0.18s ease;
+}
+.itm-dialog-title { font-family: var(--font-display); font-size: 20px; font-weight: 600; margin-bottom: 8px; }
+.itm-dialog-body { font-size: 13px; color: var(--muted); line-height: 1.6; margin-bottom: 22px; font-weight: 300; }
+.itm-dialog-actions { display: flex; gap: 10px; justify-content: flex-end; }
+
+/* Success toast */
+.itm-toast {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  background: var(--espresso); color: var(--cream);
+  padding: 12px 22px; border-radius: 8px;
+  font-family: var(--font-mono); font-size: 12px;
+  box-shadow: var(--shadow-md); z-index: 200;
+  animation: toastIn 0.25s ease;
+  white-space: nowrap;
+}
+.itm-toast.success { border-left: 3px solid var(--amber); }
+.itm-toast.error   { border-left: 3px solid var(--red); }
+
+/* Sticky order bar */
+.itm-order-bar {
+  position: sticky; bottom: 24px;
+  display: flex; align-items: center; justify-content: space-between;
+  background: var(--espresso); color: var(--cream);
+  border-radius: 10px; padding: 14px 20px;
+  box-shadow: 0 8px 32px rgba(26,15,10,0.25);
+  margin-top: 32px;
+  gap: 16px;
+  animation: slideUp 0.3s cubic-bezier(0.4,0,0.2,1);
+}
+.itm-order-bar-left { display: flex; flex-direction: column; gap: 2px; }
+.itm-order-bar-label {
+  font-family: var(--font-mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 1px;
+  color: rgba(245,240,232,0.5);
+}
+.itm-order-bar-items {
+  font-size: 12px; color: rgba(245,240,232,0.75);
+  font-family: var(--font-mono);
+}
+.itm-order-bar-total {
+  font-family: var(--font-display);
+  font-size: 26px; font-weight: 600;
+  color: var(--amber-lt); letter-spacing: -0.5px;
+}
+.itm-order-bar-actions { display: flex; gap: 10px; align-items: center; }
+.itm-order-bar-clear {
+  background: none; border: 1px solid rgba(245,240,232,0.25); border-radius: 6px;
+  padding: 8px 14px; color: rgba(245,240,232,0.6);
+  font-family: var(--font-mono); font-size: 11px; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.itm-order-bar-clear:hover { border-color: rgba(245,240,232,0.5); color: rgba(245,240,232,0.9); }
+.itm-order-bar-btn {
+  background: var(--amber); color: white;
+  border: none; border-radius: 6px;
+  padding: 9px 20px;
+  font-family: var(--font-mono); font-size: 12px;
+  cursor: pointer; transition: opacity 0.15s;
+  white-space: nowrap;
+}
+.itm-order-bar-btn:hover { opacity: 0.88; }
+
+@keyframes toastIn  { from { opacity: 0; transform: translate(-50%, 12px); } to { opacity: 1; transform: translate(-50%, 0); } }
+@keyframes slideUp  { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+
+@media (max-width: 800px) {
+  .itm-root { padding: 20px 16px 60px; }
+  .itm-header { flex-direction: column; align-items: flex-start; }
+  .itm-title { font-size: 30px; }
+  .itm-form-body { grid-template-columns: 1fr; }
+  .itm-form-body .full { grid-column: 1; }
+  .ord-body { grid-template-columns: 1fr; }
+}

--- a/web/src/pages/Items.jsx
+++ b/web/src/pages/Items.jsx
@@ -1,440 +1,648 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../services/api';
+import '../index.css';
 
-function Items() {
-  const [items, setItems] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [quantities, setQuantities] = useState({});
+/* ─── Constants ──────────────────────────── */
+
+const EMPTY_ITEM_FORM = { name: '', description: '', price: '', category: '' };
+const EMPTY_ORDER_FORM = {
+  customer_id: '', delivery_address: '', notes: '',
+  payment_method: 'cash', scheduled_date: '',
+};
+
+/* ─── Helpers ────────────────────────────── */
+
+function fmtUsd(n) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency', currency: 'USD',
+    minimumFractionDigits: 2, maximumFractionDigits: 2,
+  }).format(n ?? 0);
+}
+
+function fmtDate(iso) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+  });
+}
+
+function localDatetimeToUtcIso(localStr) {
+  if (!localStr) return null;
+  const d = new Date(localStr);
+  return d.toISOString();
+}
+
+/* ─── Toast ──────────────────────────────── */
+
+function Toast({ message, type }) {
+  return <div className={`itm-toast ${type}`}>{message}</div>;
+}
+
+/* ─── ConfirmDialog ──────────────────────── */
+
+function ConfirmDialog({ title, body, onConfirm, onCancel }) {
+  return (
+    <div className="itm-overlay" onClick={onCancel}>
+      <div className="itm-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="itm-dialog-title">{title}</div>
+        <div className="itm-dialog-body">{body}</div>
+        <div className="itm-dialog-actions">
+          <button className="btn-ghost" onClick={onCancel}>Cancel</button>
+          <button className="btn-primary" style={{ background: 'var(--red)' }} onClick={onConfirm}>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── ItemCard ───────────────────────────── */
+
+function ItemCard({ item, qty, onQtyChange, onEdit, onDelete, delay }) {
+  const selected = qty > 0;
+  return (
+    <div
+      className={`itm-card${selected ? ' selected' : ''}`}
+      style={{ animationDelay: `${delay}ms` }}
+    >
+      <div className="itm-card-body">
+        <div className="itm-card-top">
+          <div className="itm-card-name">{item.name}</div>
+          <div className="itm-card-price">{fmtUsd(item.price)}</div>
+        </div>
+        {item.description && (
+          <div className="itm-card-desc">{item.description}</div>
+        )}
+        <div className="itm-qty-row">
+          <button className="itm-qty-btn"
+            onClick={() => onQtyChange(item.id, qty - 1)}>−</button>
+          <input
+            className="itm-qty-input"
+            type="number" min="0"
+            value={qty}
+            onChange={(e) => onQtyChange(item.id, e.target.value)}
+          />
+          <button className="itm-qty-btn"
+            onClick={() => onQtyChange(item.id, qty + 1)}>+</button>
+        </div>
+      </div>
+      <div className="itm-card-footer">
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--muted)' }}>
+          {selected ? `${fmtUsd(item.price * qty)} selected` : '\u00a0'}
+        </span>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn-ghost" style={{ padding: '5px 11px', fontSize: 11 }}
+            onClick={() => onEdit(item)}>Edit</button>
+          <button className="btn-danger" onClick={() => onDelete(item)}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Items ──────────────────────────────── */
+
+export default function Items() {
+  const [items, setItems]         = useState([]);
   const [customers, setCustomers] = useState([]);
-  const [showOrderForm, setShowOrderForm] = useState(false);
-  const [showItemForm, setShowItemForm] = useState(false);
-  const [editingItem, setEditingItem] = useState(null);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState('');
-  const [customerOrderHistory, setCustomerOrderHistory] = useState([]);
-  const [loadingHistory, setLoadingHistory] = useState(false);
-  const [orderForm, setOrderForm] = useState({
-    customer_id: '',
-    delivery_address: '',
-    notes: '',
-    payment_method: 'cash',
-    scheduled_date: ''
-  });
-  const [itemForm, setItemForm] = useState({
-    name: '',
-    description: '',
-    price: '',
-    category: ''
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
+  const [quantities, setQuantities] = useState({});
+
+  const [itemFormOpen, setItemFormOpen]   = useState(false);
+  const [editingItem, setEditingItem]     = useState(null);
+  const [itemForm, setItemForm]           = useState(EMPTY_ITEM_FORM);
+  const [itemFormError, setItemFormError] = useState(null);
+  const [itemSubmitting, setItemSubmitting] = useState(false);
+
+  const [orderFormOpen, setOrderFormOpen]   = useState(false);
+  const [orderForm, setOrderForm]           = useState(EMPTY_ORDER_FORM);
+  const [orderFormError, setOrderFormError] = useState(null);
+  const [orderSubmitting, setOrderSubmitting] = useState(false);
+  const [orderHistory, setOrderHistory]     = useState([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  const [search, setSearch]             = useState('');
+  const [catFilter, setCatFilter]       = useState('');
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [toast, setToast]               = useState(null);
+
+  /* ── Derived ── */
+  const categories = [...new Set(items.map((i) => i.category).filter(Boolean))].sort();
+
+  const filteredItems = items.filter((item) => {
+    const s = search.toLowerCase();
+    const matchSearch = !search ||
+      item.name?.toLowerCase().includes(s) ||
+      item.description?.toLowerCase().includes(s);
+    const matchCat = !catFilter || item.category === catFilter;
+    return matchSearch && matchCat;
   });
 
-  useEffect(() => {
-    loadData();
-  }, []);
+  const groupedItems = filteredItems.reduce((acc, item) => {
+    const cat = item.category || 'Uncategorised';
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(item);
+    return acc;
+  }, {});
 
-  const loadData = async () => {
+  const selectedItems = items.filter((i) => (quantities[i.id] || 0) > 0);
+  const totalAmount = selectedItems.reduce(
+    (sum, i) => sum + i.price * (quantities[i.id] || 0), 0
+  );
+  const totalQty = selectedItems.reduce((sum, i) => sum + (quantities[i.id] || 0), 0);
+
+  /* ── Helpers ── */
+  const showToast = (message, type = 'success') => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const resetQty = () => {
+    setQuantities((prev) => {
+      const r = { ...prev };
+      Object.keys(r).forEach((k) => (r[k] = 0));
+      return r;
+    });
+  };
+
+  /* ── Load ── */
+  const load = useCallback(async () => {
     try {
-      setLoading(true);
+      setLoading(true); setError(null);
       const [itemsData, customersData] = await Promise.all([
-        api.getItems(),
-        api.getCustomers()
+        api.getItems(), api.getCustomers(),
       ]);
-      setItems(itemsData);
-      setCustomers(customersData);
-      const initialQuantities = {};
-      itemsData.forEach(item => {
-        initialQuantities[item.id] = 0;
+      setItems(itemsData || []);
+      setCustomers(customersData || []);
+      setQuantities((prev) => {
+        const next = {};
+        (itemsData || []).forEach((i) => { next[i.id] = prev[i.id] || 0; });
+        return next;
       });
-      setQuantities(initialQuantities);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  /* ── Quantity ── */
+  const handleQty = (itemId, raw) => {
+    const qty = Math.max(0, parseInt(raw) || 0);
+    setQuantities((prev) => ({ ...prev, [itemId]: qty }));
   };
 
-  const handleQuantityChange = (itemId, value) => {
-    const qty = Math.max(0, parseInt(value) || 0);
-    setQuantities(prev => ({ ...prev, [itemId]: qty }));
+  /* ── Item form ── */
+  const openCreate = () => {
+    setItemForm(EMPTY_ITEM_FORM);
+    setEditingItem(null);
+    setItemFormError(null);
+    setItemFormOpen(true);
+    setOrderFormOpen(false);
   };
 
-  const getTotalAmount = () => {
-    return items.reduce((total, item) => {
-      return total + (item.price * (quantities[item.id] || 0));
-    }, 0);
+  const openEdit = (item) => {
+    setItemForm({
+      name: item.name, description: item.description || '',
+      price: String(item.price), category: item.category || '',
+    });
+    setEditingItem(item);
+    setItemFormError(null);
+    setItemFormOpen(true);
+    setOrderFormOpen(false);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const getSelectedItems = () => {
-    return items.filter(item => quantities[item.id] > 0);
+  const closeItemForm = () => {
+    setItemFormOpen(false); setEditingItem(null);
+    setItemForm(EMPTY_ITEM_FORM); setItemFormError(null);
+  };
+
+  const handleItemSubmit = async (e) => {
+    e.preventDefault();
+    setItemSubmitting(true); setItemFormError(null);
+    try {
+      const payload = { ...itemForm, price: parseFloat(itemForm.price), available: true };
+      if (editingItem) {
+        await api.updateItem(editingItem.id, payload);
+        showToast('Item updated');
+      } else {
+        await api.createItem(payload);
+        showToast('Item created');
+      }
+      closeItemForm(); load();
+    } catch (err) {
+      setItemFormError(err.message);
+    } finally {
+      setItemSubmitting(false);
+    }
+  };
+
+  const itemField = (key) => ({
+    value: itemForm[key],
+    onChange: (e) => setItemForm((p) => ({ ...p, [key]: e.target.value })),
+    className: 'itm-input',
+  });
+
+  /* ── Delete ── */
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await api.deleteItem(deleteTarget.id);
+      setDeleteTarget(null);
+      showToast('Item deleted');
+      load();
+    } catch (err) {
+      setDeleteTarget(null);
+      showToast(err.message, 'error');
+    }
+  };
+
+  /* ── Order form ── */
+  const openOrderForm = () => {
+    setOrderFormOpen(true);
+    setItemFormOpen(false);
+    setOrderFormError(null);
+    setOrderHistory([]);
+  };
+
+  const closeOrderForm = () => {
+    setOrderFormOpen(false);
+    setOrderForm(EMPTY_ORDER_FORM);
+    setOrderFormError(null);
+    setOrderHistory([]);
   };
 
   const handleCustomerChange = async (customerId) => {
-    const customer = customers.find(c => c.id === parseInt(customerId));
-    setOrderForm(prev => ({
-      ...prev,
+    const customer = customers.find((c) => c.id === parseInt(customerId));
+    setOrderForm((p) => ({
+      ...p,
       customer_id: customerId,
-      delivery_address: customer?.address || prev.delivery_address
+      delivery_address: customer?.address || p.delivery_address,
     }));
-    
-    // Fetch customer order history
-    if (customerId) {
-      try {
-        setLoadingHistory(true);
-        const orders = await api.getOrdersByCustomer(customerId);
-        setCustomerOrderHistory(orders || []);
-      } catch (err) {
-        console.error('Error fetching order history:', err);
-        setCustomerOrderHistory([]);
-      } finally {
-        setLoadingHistory(false);
-      }
-    } else {
-      setCustomerOrderHistory([]);
+    setOrderHistory([]);
+    if (!customerId) return;
+    try {
+      setHistoryLoading(true);
+      const orders = await api.getOrdersByCustomer(customerId);
+      setOrderHistory(orders || []);
+    } catch {
+      setOrderHistory([]);
+    } finally {
+      setHistoryLoading(false);
     }
   };
 
-  const handleCreateOrder = async (e) => {
+  const handleOrderSubmit = async (e) => {
     e.preventDefault();
-    const selectedItems = getSelectedItems();
     if (selectedItems.length === 0) {
-      alert('Please select at least one item');
+      setOrderFormError('Select at least one item from the menu below.');
       return;
     }
-
-    const orderItems = selectedItems.map(item => ({
-      item_id: item.id,
-      quantity: quantities[item.id]
-    }));
-
+    setOrderSubmitting(true); setOrderFormError(null);
     try {
-      // Convert datetime-local (in user's local timezone) to UTC for storage
-      // datetime-local format: "2026-03-06T14:30" represents user's local time
-      // We need to convert to UTC before sending to backend
-      let scheduledDateISO = null;
-      if (orderForm.scheduled_date) {
-        // Parse the local datetime and convert to UTC
-        const localDate = new Date(orderForm.scheduled_date);
-        // Get UTC components
-        const year = localDate.getUTCFullYear();
-        const month = String(localDate.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(localDate.getUTCDate()).padStart(2, '0');
-        const hours = String(localDate.getUTCHours()).padStart(2, '0');
-        const minutes = String(localDate.getUTCMinutes()).padStart(2, '0');
-        const seconds = '00';
-        scheduledDateISO = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}Z`;
-      }
-      
       await api.createOrder({
         customer_id: parseInt(orderForm.customer_id) || null,
         delivery_address: orderForm.delivery_address,
         notes: orderForm.notes,
         payment_method: orderForm.payment_method,
-        scheduled_date: scheduledDateISO,
-        items: orderItems
+        scheduled_date: localDatetimeToUtcIso(orderForm.scheduled_date),
+        items: selectedItems.map((i) => ({ item_id: i.id, quantity: quantities[i.id] })),
       });
-      alert('Order created successfully!');
-      setShowOrderForm(false);
-      setQuantities(prev => {
-        const reset = { ...prev };
-        Object.keys(reset).forEach(key => reset[key] = 0);
-        return reset;
-      });
-      setOrderForm({ customer_id: '', delivery_address: '', notes: '', payment_method: 'cash', scheduled_date: '' });
+      showToast('Order placed successfully');
+      closeOrderForm();
+      resetQty();
     } catch (err) {
-      alert(err.message);
+      setOrderFormError(err.message);
+    } finally {
+      setOrderSubmitting(false);
     }
   };
 
-  const handleItemSubmit = async (e) => {
-    e.preventDefault();
-    try {
-      if (editingItem) {
-        await api.updateItem(editingItem.id, {
-          ...itemForm,
-          price: parseFloat(itemForm.price),
-          available: true
-        });
-      } else {
-        await api.createItem({
-          ...itemForm,
-          price: parseFloat(itemForm.price),
-          available: true
-        });
-      }
-      setShowItemForm(false);
-      setEditingItem(null);
-      setItemForm({ name: '', description: '', price: '', category: '' });
-      loadData();
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-
-  const handleEditItem = (item) => {
-    setItemForm({
-      name: item.name,
-      description: item.description || '',
-      price: String(item.price),
-      category: item.category || ''
-    });
-    setEditingItem(item);
-    setShowItemForm(true);
-  };
-
-  const handleDeleteItem = async (id) => {
-    if (!confirm('Delete this item?')) return;
-    try {
-      await api.deleteItem(id);
-      loadData();
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-
-  const handleCancelItem = () => {
-    setShowItemForm(false);
-    setEditingItem(null);
-    setItemForm({ name: '', description: '', price: '', category: '' });
-  };
-
-  const filteredItems = items.filter(item => {
-    const search = searchTerm.toLowerCase();
-    const matchesSearch = !searchTerm || 
-      item.name?.toLowerCase().includes(search) ||
-      item.description?.toLowerCase().includes(search);
-    const matchesCategory = !categoryFilter || item.category === categoryFilter;
-    return matchesSearch && matchesCategory;
+  const ordField = (key) => ({
+    value: orderForm[key],
+    onChange: (e) => setOrderForm((p) => ({ ...p, [key]: e.target.value })),
   });
 
-  const groupedItems = filteredItems.reduce((acc, item) => {
-    if (!acc[item.category]) {
-      acc[item.category] = [];
-    }
-    acc[item.category].push(item);
-    return acc;
-  }, {});
-
-  const categories = [...new Set(items.map(item => item.category))];
-
-  if (loading) return <div className="loading">Loading items...</div>;
-  if (error) return <div className="error">Error: {error}</div>;
-
+  /* ── Render ── */
   return (
-    <div className="page">
-      <div className="page-header">
-        <h1>Menu Items</h1>
-        <div className="header-buttons">
-          <button 
-            className="btn-secondary"
-            onClick={() => setShowItemForm(!showItemForm)}
-          >
-            {showItemForm ? 'Cancel' : '+ Add Item'}
-          </button>
-          <button 
-            className="btn-primary" 
-            onClick={() => setShowOrderForm(!showOrderForm)}
-            disabled={getTotalAmount() === 0}
-          >
-            {showOrderForm ? 'Cancel' : `Order ($${getTotalAmount().toFixed(2)})`}
-          </button>
-        </div>
-      </div>
+    <>
+      <div className="itm-root">
 
-      <div className="filters">
-        <input
-          type="text"
-          placeholder="Search items..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="search-input"
-        />
-        <select
-          value={categoryFilter}
-          onChange={(e) => setCategoryFilter(e.target.value)}
-          className="filter-select"
-        >
-          <option value="">All Categories</option>
-          {categories.map(cat => (
-            <option key={cat} value={cat}>{cat}</option>
-          ))}
-        </select>
-      </div>
+        {toast && <Toast message={toast.message} type={toast.type} />}
 
-      {showItemForm && (
-        <form onSubmit={handleItemSubmit} className="form">
-          <h3>{editingItem ? 'Edit Item' : 'Add New Item'}</h3>
-          <input
-            type="text"
-            placeholder="Item Name"
-            value={itemForm.name}
-            onChange={(e) => setItemForm({ ...itemForm, name: e.target.value })}
-            required
+        {deleteTarget && (
+          <ConfirmDialog
+            title="Delete item?"
+            body={<><strong>{deleteTarget.name}</strong> will be permanently removed from the menu.</>}
+            onConfirm={confirmDelete}
+            onCancel={() => setDeleteTarget(null)}
           />
-          <input
-            type="text"
-            placeholder="Description"
-            value={itemForm.description}
-            onChange={(e) => setItemForm({ ...itemForm, description: e.target.value })}
-          />
-          <input
-            type="number"
-            placeholder="Price"
-            step="0.01"
-            value={itemForm.price}
-            onChange={(e) => setItemForm({ ...itemForm, price: e.target.value })}
-            required
-          />
-          <input
-            type="text"
-            placeholder="Category"
-            value={itemForm.category}
-            onChange={(e) => setItemForm({ ...itemForm, category: e.target.value })}
-            required
-          />
-          <div className="form-actions">
-            <button type="submit" className="btn-primary">
-              {editingItem ? 'Update Item' : 'Add Item'}
-            </button>
-            {editingItem && (
-              <button type="button" className="btn-secondary" onClick={handleCancelItem}>
-                Cancel
-              </button>
-            )}
-          </div>
-        </form>
-      )}
+        )}
 
-      {showOrderForm && (
-        <form onSubmit={handleCreateOrder} className="form">
-          <h3>Create Order</h3>
-          <select
-            value={orderForm.customer_id}
-            onChange={(e) => handleCustomerChange(e.target.value)}
-          >
-            <option value="">Select Customer</option>
-            {customers.map(c => (
-              <option key={c.id} value={c.id}>{c.name}</option>
-            ))}
-          </select>
-          <input
-            type="text"
-            placeholder="Delivery Address"
-            value={orderForm.delivery_address}
-            onChange={(e) => setOrderForm({ ...orderForm, delivery_address: e.target.value })}
-          />
-          <input
-            type="text"
-            placeholder="Notes"
-            value={orderForm.notes}
-            onChange={(e) => setOrderForm({ ...orderForm, notes: e.target.value })}
-          />
-          <select
-            value={orderForm.payment_method}
-            onChange={(e) => setOrderForm({ ...orderForm, payment_method: e.target.value })}
-          >
-            <option value="cash">Cash</option>
-            <option value="e-transfer">e-Transfer</option>
-          </select>
-          <input
-            type="datetime-local"
-            value={orderForm.scheduled_date}
-            onChange={(e) => setOrderForm({ ...orderForm, scheduled_date: e.target.value })}
-          />
-          <div className="order-summary">
-            <h4>Order Summary:</h4>
-            {getSelectedItems().map(item => (
-              <p key={item.id}>
-                {quantities[item.id]}x {item.name} - ${(item.price * quantities[item.id]).toFixed(2)}
-              </p>
-            ))}
-            <p><strong>Total: ${getTotalAmount().toFixed(2)}</strong></p>
-          </div>
-          <button type="submit" className="btn-primary">Place Order</button>
-        </form>
-      )}
-
-      {showOrderForm && orderForm.customer_id && (
-        <div className="order-history-panel">
-          <h3>Customer Order History</h3>
-          {loadingHistory ? (
-            <p className="loading">Loading order history...</p>
-          ) : customerOrderHistory.length === 0 ? (
-            <p className="empty">No previous orders for this customer</p>
-          ) : (
-            <div className="order-history-list">
-              {customerOrderHistory.map((order) => (
-                <div key={order.id} className="history-order-card">
-                  <div className="history-order-header">
-                    <span className="order-id">Order #{order.id}</span>
-                    <span className="order-date">
-                      {new Date(order.created_at).toLocaleDateString('en-US', { 
-                        month: 'short', 
-                        day: 'numeric', 
-                        year: 'numeric' 
-                      })}
-                    </span>
-                  </div>
-                  <div className="history-order-items">
-                    {order.order_items && order.order_items.length > 0 
-                      ? order.order_items.map(item => `${item.quantity}x ${item.item_name}`).join(', ')
-                      : 'No items'}
-                  </div>
-                  <div className="history-order-footer">
-                    <span className="order-total">${order.total_amount ? order.total_amount.toFixed(2) : '0.00'}</span>
-                    <span className="order-status">{order.status}</span>
-                  </div>
-                </div>
-              ))}
+        {/* Header */}
+        <div className="itm-header">
+          <div>
+            <h1 className="itm-title">The <em>Menu</em></h1>
+            <div className="itm-meta">
+              {items.length} item{items.length !== 1 ? 's' : ''}
+              {categories.length > 0 && ` · ${categories.length} categories`}
             </div>
-          )}
+          </div>
+          <div className="itm-header-actions">
+            {itemFormOpen
+              ? <button className="btn-ghost" onClick={closeItemForm}>✕ Cancel</button>
+              : <button className="btn-primary" onClick={openCreate}>+ Add Item</button>
+            }
+          </div>
         </div>
-      )}
 
-      {Object.entries(groupedItems).map(([category, categoryItems]) => (
-        <div key={category} className="category-section">
-          <h2 className="category-title">{category}</h2>
-          <div className="card-grid">
-            {categoryItems.map((item) => (
-              <div key={item.id} className="card">
-                <div className="card-header">
-                  <h3>{item.name}</h3>
-                  <span className="item-price">${item.price.toFixed(2)}</span>
-                </div>
-                <div className="card-body">
-                  <p>{item.description}</p>
-                </div>
-                <div className="card-actions quantity-selector">
-                  <button 
-                    className="qty-btn"
-                    onClick={() => handleQuantityChange(item.id, (quantities[item.id] || 0) - 1)}
+        {/* Item form */}
+        <div className={`itm-panel-wrap ${itemFormOpen ? 'open' : 'closed'}`}>
+          <form className="itm-panel" onSubmit={handleItemSubmit}>
+            <div className="itm-panel-head">
+              <div className="itm-panel-title">
+                {editingItem ? <>Edit <em>item</em></> : <>New <em>item</em></>}
+              </div>
+            </div>
+            {itemFormError && <div className="itm-form-error">{itemFormError}</div>}
+            <div className="itm-form-body">
+              <div className="itm-field full">
+                <label className="itm-label">Name *</label>
+                <input {...itemField('name')} placeholder="e.g. Margherita Pizza" required />
+              </div>
+              <div className="itm-field full">
+                <label className="itm-label">Description</label>
+                <input {...itemField('description')} placeholder="Short description" />
+              </div>
+              <div className="itm-field">
+                <label className="itm-label">Price *</label>
+                <input {...itemField('price')} type="number" step="0.01" min="0"
+                  placeholder="0.00" required />
+              </div>
+              <div className="itm-field">
+                <label className="itm-label">Category *</label>
+                <input {...itemField('category')} placeholder="e.g. mains, drinks…" required />
+              </div>
+            </div>
+            <div className="itm-form-actions">
+              <button type="submit" className="btn-primary" disabled={itemSubmitting}>
+                {itemSubmitting ? 'Saving…' : editingItem ? 'Update item' : 'Create item'}
+              </button>
+              <button type="button" className="btn-ghost" onClick={closeItemForm}>Cancel</button>
+            </div>
+          </form>
+        </div>
+
+        {/* Order form */}
+        <div className={`itm-panel-wrap ${orderFormOpen ? 'open' : 'closed'}`}>
+          <form className="itm-panel" onSubmit={handleOrderSubmit}>
+            <div className="itm-panel-head">
+              <div className="itm-panel-title">New <em>order</em></div>
+              <button type="button" className="btn-ghost" onClick={closeOrderForm}
+                style={{ padding: '5px 12px', fontSize: 11 }}>✕</button>
+            </div>
+            {orderFormError && <div className="itm-form-error">{orderFormError}</div>}
+            <div className="ord-body">
+              {/* Left col — form fields */}
+              <div className="ord-col">
+                <div className="itm-field">
+                  <label className="itm-label">Customer</label>
+                  <select
+                    className="itm-select"
+                    value={orderForm.customer_id}
+                    onChange={(e) => handleCustomerChange(e.target.value)}
                   >
-                    -
-                  </button>
-                  <input
-                    type="number"
-                    min="0"
-                    value={quantities[item.id] || 0}
-                    onChange={(e) => handleQuantityChange(item.id, e.target.value)}
-                    className="qty-input"
-                  />
-                  <button 
-                    className="qty-btn"
-                    onClick={() => handleQuantityChange(item.id, (quantities[item.id] || 0) + 1)}
-                  >
-                    +
-                  </button>
+                    <option value="">No customer</option>
+                    {customers.map((c) => (
+                      <option key={c.id} value={c.id}>{c.name}</option>
+                    ))}
+                  </select>
                 </div>
-                <div className="card-actions">
-                  <button className="btn-primary" onClick={() => handleEditItem(item)}>Edit</button>
-                  <button className="btn-danger" onClick={() => handleDeleteItem(item.id)}>Delete</button>
+                <div className="itm-field">
+                  <label className="itm-label">Delivery Address</label>
+                  <input className="itm-input" {...ordField('delivery_address')}
+                    placeholder="Street address" />
+                </div>
+                <div className="itm-field">
+                  <label className="itm-label">Payment Method</label>
+                  <select className="itm-select" value={orderForm.payment_method}
+                    onChange={(e) => setOrderForm((p) => ({ ...p, payment_method: e.target.value }))}>
+                    <option value="cash">Cash</option>
+                    <option value="e-transfer">e-Transfer</option>
+                  </select>
+                </div>
+                <div className="itm-field">
+                  <label className="itm-label">Scheduled Date</label>
+                  <input className="itm-input" type="datetime-local"
+                    value={orderForm.scheduled_date}
+                    onChange={(e) => setOrderForm((p) => ({ ...p, scheduled_date: e.target.value }))} />
+                </div>
+                <div className="itm-field">
+                  <label className="itm-label">Notes</label>
+                  <input className="itm-input" {...ordField('notes')}
+                    placeholder="Any special instructions" />
+                </div>
+              </div>
+
+              {/* Right col — summary + history */}
+              <div className="ord-col">
+                {/* Order summary */}
+                <div className="ord-summary">
+                  <div className="ord-summary-title">Order summary</div>
+                  {selectedItems.length === 0
+                    ? <div className="ord-summary-empty">Select items from the menu below</div>
+                    : <>
+                        {selectedItems.map((item) => (
+                          <div key={item.id} className="ord-line">
+                            <span className="ord-line-name">{item.name}</span>
+                            <span className="ord-line-qty">×{quantities[item.id]}</span>
+                            <span className="ord-line-price">
+                              {fmtUsd(item.price * quantities[item.id])}
+                            </span>
+                          </div>
+                        ))}
+                        <div className="ord-total">
+                          <span className="ord-total-label">Total</span>
+                          <span className="ord-total-value">{fmtUsd(totalAmount)}</span>
+                        </div>
+                      </>
+                  }
+                </div>
+
+                {/* Customer order history */}
+                {orderForm.customer_id && (
+                  <div className="ord-history">
+                    <div className="ord-history-title">Order history</div>
+                    {historyLoading
+                      ? <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--muted)' }}>
+                          Loading…
+                        </div>
+                      : orderHistory.length === 0
+                        ? <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--rule)', fontStyle: 'italic' }}>
+                            No previous orders
+                          </div>
+                        : orderHistory.map((order) => (
+                            <div key={order.id} className="ord-hist-row">
+                              <div className="ord-hist-top">
+                                <span className="ord-hist-id">#{order.id}</span>
+                                <span className="ord-hist-date">{fmtDate(order.created_at)}</span>
+                              </div>
+                              <div className="ord-hist-items">
+                                {order.order_items?.length
+                                  ? order.order_items.map((i) => `${i.quantity}× ${i.item_name}`).join(', ')
+                                  : 'No items'}
+                              </div>
+                              <div className="ord-hist-footer">
+                                <span className="ord-hist-total">{fmtUsd(order.total_amount)}</span>
+                                <span className="ord-hist-status">{order.status}</span>
+                              </div>
+                            </div>
+                          ))
+                    }
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="itm-form-actions">
+              <button type="submit" className="btn-order" disabled={orderSubmitting || selectedItems.length === 0}>
+                {orderSubmitting ? 'Placing…' : `Place order · ${fmtUsd(totalAmount)}`}
+              </button>
+              <button type="button" className="btn-ghost" onClick={closeOrderForm}>Cancel</button>
+            </div>
+          </form>
+        </div>
+
+        {/* Loading */}
+        {loading && (
+          <div className="itm-load">
+            <div className="itm-spinner" />
+            <span className="itm-load-text">Loading menu…</span>
+          </div>
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <div className="itm-error">
+            <p className="itm-error-msg">{error}</p>
+            <button className="itm-retry" onClick={load}>Try again</button>
+          </div>
+        )}
+
+        {/* Content */}
+        {!loading && !error && (
+          <>
+            {/* Filters */}
+            <div className="itm-filters">
+              <div className="itm-search-wrap">
+                <span className="itm-search-icon"><SearchIcon /></span>
+                <input
+                  className="itm-search"
+                  type="text"
+                  placeholder="Search menu…"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </div>
+              <div className="itm-cat-pills">
+                <button
+                  className={`itm-cat-pill${catFilter === '' ? ' active' : ''}`}
+                  onClick={() => setCatFilter('')}
+                >All</button>
+                {categories.map((cat) => (
+                  <button
+                    key={cat}
+                    className={`itm-cat-pill${catFilter === cat ? ' active' : ''}`}
+                    onClick={() => setCatFilter(cat === catFilter ? '' : cat)}
+                  >{cat}</button>
+                ))}
+              </div>
+            </div>
+
+            {/* Empty states */}
+            {items.length === 0 && (
+              <div className="itm-empty">
+                <span style={{ fontSize: 32, opacity: 0.25 }}>✦</span>
+                <div className="itm-empty-title">Menu is empty</div>
+                <div className="itm-empty-sub">Add your first item to get started.</div>
+              </div>
+            )}
+
+            {items.length > 0 && filteredItems.length === 0 && (
+              <div className="itm-empty">
+                <div className="itm-empty-title">No items found</div>
+                <div className="itm-empty-sub">Try a different search or category.</div>
+              </div>
+            )}
+
+            {/* Category sections */}
+            {Object.entries(groupedItems).map(([category, catItems], gi) => (
+              <div
+                key={category}
+                className="itm-category"
+                style={{ animationDelay: `${gi * 60}ms` }}
+              >
+                <div className="itm-cat-head">
+                  <h2 className="itm-cat-name">{category}</h2>
+                  <span className="itm-cat-count">
+                    {catItems.length} item{catItems.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                <div className="itm-grid">
+                  {catItems.map((item, ii) => (
+                    <ItemCard
+                      key={item.id}
+                      item={item}
+                      qty={quantities[item.id] || 0}
+                      onQtyChange={handleQty}
+                      onEdit={openEdit}
+                      onDelete={(i) => setDeleteTarget(i)}
+                      delay={gi * 60 + ii * 40}
+                    />
+                  ))}
                 </div>
               </div>
             ))}
-          </div>
-        </div>
-      ))}
-    </div>
+
+            {/* Sticky order bar — visible when items selected */}
+            {totalQty > 0 && (
+              <div className="itm-order-bar">
+                <div className="itm-order-bar-left">
+                  <span className="itm-order-bar-label">
+                    {totalQty} item{totalQty !== 1 ? 's' : ''} selected
+                  </span>
+                  <span className="itm-order-bar-items">
+                    {selectedItems.map((i) => `${quantities[i.id]}× ${i.name}`).join(' · ')}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+                  <span className="itm-order-bar-total">{fmtUsd(totalAmount)}</span>
+                  <div className="itm-order-bar-actions">
+                    <button className="itm-order-bar-clear" onClick={resetQty}>Clear</button>
+                    <button className="itm-order-bar-btn" onClick={openOrderForm}>
+                      Place Order →
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+      </div>
+    </>
   );
 }
 
-export default Items;
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract Items page CSS from inline <style> tag to centralized index.css
- Items page redesign with warm editorial design (cream base, espresso text, amber accents)
- Add slide-down panels for item form and order form
- Category pill filters for filtering menu items
- Sticky order bar when items are selected
- Customer order history panel in order form
- Toast notifications for success/error feedback
- Confirm dialog for delete functionality
- Use CSS animations (fadeUp, fadeIn, scaleIn, slideUp, toastIn, spin)
- Keep design tokens consistent with other pages (Dashboard, Home, Schedule, Customers)
- Build passes successfully