### PR TITLE
feat: orders page revamp with warm editorial design

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2914,3 +2914,355 @@ body {
   .nav-link { font-size: 10px; padding: 5px 9px; }
   .nav-brand-word { font-size: 16px; }
 }
+
+/* Orders Page - Warm editorial design */
+.ord-root {
+  min-height: 100vh;
+  background: var(--cream);
+  color: var(--espresso);
+  font-family: var(--font-body);
+  padding: 36px 40px 80px;
+}
+
+/* Status palette */
+.ord-root { --s-pending: #b45309; --s-preparing: #1d4ed8; --s-ready: #6d28d9; --s-delivered: #065f46; --s-cancelled: #991b1b; }
+
+/* Header */
+.ord-header {
+  display: flex; align-items: flex-end;
+  justify-content: space-between;
+  padding-bottom: 20px;
+  border-bottom: 2px solid var(--espresso);
+  margin-bottom: 28px;
+  gap: 16px; flex-wrap: wrap;
+}
+.ord-title {
+  font-family: var(--font-display);
+  font-size: 38px; font-weight: 700;
+  letter-spacing: -0.5px; line-height: 1;
+}
+.ord-title em { font-style: italic; color: var(--amber); }
+.ord-meta {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--muted);
+  margin-top: 6px; letter-spacing: 0.3px;
+}
+
+/* Buttons */
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: var(--espresso); color: var(--cream);
+  border: none; border-radius: 6px; padding: 8px 16px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.3px;
+  cursor: pointer; transition: opacity 0.15s; text-decoration: none;
+  white-space: nowrap;
+}
+.btn-primary:hover { opacity: 0.78; }
+
+.btn-ghost {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: none; color: var(--muted);
+  border: 1.5px solid var(--rule); border-radius: 6px;
+  padding: 7px 14px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.3px;
+  cursor: pointer; transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.btn-ghost:hover { border-color: var(--brown); color: var(--brown); }
+
+.btn-danger {
+  display: inline-flex; align-items: center;
+  background: none; color: var(--red);
+  border: 1.5px solid rgba(160,43,43,0.3); border-radius: 6px;
+  padding: 6px 12px;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.3px;
+  cursor: pointer; transition: background 0.15s, border-color 0.15s;
+}
+.btn-danger:hover { background: var(--red-bg); border-color: var(--red); }
+
+/* Filters bar */
+.ord-filters {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 18px; flex-wrap: wrap;
+}
+.ord-search-wrap {
+  position: relative; flex: 1;
+  min-width: 200px; max-width: 320px;
+}
+.ord-search-icon {
+  position: absolute; left: 12px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted); pointer-events: none;
+}
+.ord-search {
+  width: 100%; background: white;
+  border: 1.5px solid var(--rule); border-radius: 7px;
+  padding: 9px 12px 9px 34px;
+  font-family: var(--font-mono); font-size: 12px; color: var(--espresso);
+  outline: none; transition: border-color 0.15s;
+}
+.ord-search::placeholder { color: var(--muted); }
+.ord-search:focus { border-color: var(--amber); }
+
+.ord-select {
+  background: white; border: 1.5px solid var(--rule); border-radius: 7px;
+  padding: 9px 32px 9px 12px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--espresso);
+  outline: none; cursor: pointer; transition: border-color 0.15s;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 24 24' fill='none' stroke='%238a7060' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 10px center;
+}
+.ord-select:focus { border-color: var(--amber); }
+
+/* Section controls */
+.ord-controls {
+  display: flex; gap: 8px;
+  margin-bottom: 24px;
+}
+
+/* Status sections */
+.ord-section {
+  margin-bottom: 6px;
+  border: 1.5px solid var(--rule);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: white;
+  box-shadow: var(--shadow-sm);
+}
+
+.ord-section-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 18px;
+  cursor: pointer; background: none; border: none;
+  width: 100%; text-align: left;
+  border-left: 4px solid transparent;
+  transition: background 0.12s;
+}
+.ord-section-head:hover { background: var(--cream); }
+
+.ord-section-chevron {
+  color: var(--muted); flex-shrink: 0;
+  transition: transform 0.2s;
+}
+.ord-section-chevron.open { transform: rotate(90deg); }
+
+.ord-section-dot {
+  width: 9px; height: 9px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.ord-section-label {
+  font-family: var(--font-mono);
+  font-size: 11px; text-transform: uppercase;
+  letter-spacing: 1px; font-weight: 500;
+  flex: 1;
+}
+.ord-section-count {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--muted);
+  background: var(--cream-2);
+  border-radius: 10px; padding: 2px 9px;
+}
+
+.ord-section-body {
+  border-top: 1px solid var(--rule);
+  padding: 16px;
+}
+
+.ord-empty-section {
+  font-family: var(--font-mono);
+  font-size: 11px; color: var(--muted);
+  font-style: italic; padding: 12px 4px;
+  letter-spacing: 0.3px;
+}
+
+/* Order cards */
+.ord-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+}
+
+.ord-card {
+  background: var(--cream);
+  border: 1.5px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  opacity: 0;
+  animation: fadeUp 0.35s ease forwards;
+}
+.ord-card:hover { box-shadow: var(--shadow-md); border-color: var(--cream-3); }
+
+.ord-card-top {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--rule);
+  background: white;
+}
+.ord-card-id {
+  font-family: var(--font-display);
+  font-size: 15px; font-weight: 600;
+}
+.ord-status-pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--font-mono); font-size: 10px;
+  text-transform: capitalize; letter-spacing: 0.5px;
+  border-radius: 12px; padding: 3px 9px;
+  border: 1px solid;
+}
+.ord-status-dot { width: 6px; height: 6px; border-radius: 50%; }
+
+.ord-card-body {
+  padding: 12px 14px; flex: 1;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.ord-customer {
+  font-family: var(--font-display);
+  font-size: 15px; font-weight: 600;
+  color: var(--espresso); line-height: 1.2;
+}
+.ord-customer.anonymous { color: var(--muted); font-style: italic; font-size: 13px; }
+
+.ord-detail {
+  display: flex; align-items: baseline; gap: 8px;
+  font-size: 12px;
+}
+.ord-detail-label {
+  font-family: var(--font-mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.7px;
+  color: var(--muted); flex-shrink: 0; width: 54px;
+}
+.ord-detail-value { color: var(--brown); font-size: 12px; }
+.ord-detail-value.na { color: var(--rule); font-style: italic; }
+
+/* Items list */
+.ord-items {
+  margin-top: 2px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.ord-item-row {
+  display: flex; align-items: baseline; gap: 6px;
+  font-size: 12px; color: var(--brown);
+}
+.ord-item-qty {
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--muted); flex-shrink: 0; width: 24px;
+  text-align: right;
+}
+
+/* Total */
+.ord-total {
+  display: flex; align-items: baseline; gap: 6px;
+  margin-top: 4px; padding-top: 8px;
+  border-top: 1px solid var(--rule);
+}
+.ord-total-label {
+  font-family: var(--font-mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.7px; color: var(--muted);
+  flex: 1;
+}
+.ord-total-value {
+  font-family: var(--font-display);
+  font-size: 18px; font-weight: 600; color: var(--espresso);
+}
+
+/* Card footer */
+.ord-card-footer {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px 12px;
+  border-top: 1px solid var(--rule);
+  background: white;
+  flex-wrap: wrap;
+}
+
+/* Inline status select */
+.ord-status-select {
+  flex: 1; min-width: 110px;
+  background: var(--cream); border: 1.5px solid var(--rule); border-radius: 6px;
+  padding: 6px 24px 6px 10px;
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.4px;
+  color: var(--espresso); outline: none; cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238a7060' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 8px center;
+  transition: border-color 0.15s;
+}
+.ord-status-select:focus { border-color: var(--amber); }
+
+/* Confirm dialog */
+.ord-overlay {
+  position: fixed; inset: 0;
+  background: rgba(26,15,10,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 100; animation: fadeIn 0.15s ease;
+}
+.ord-dialog {
+  background: white; border: 1.5px solid var(--rule); border-radius: var(--radius);
+  padding: 28px 28px 22px; max-width: 360px; width: 90%;
+  box-shadow: var(--shadow-md); animation: scaleIn 0.18s ease;
+}
+.ord-dialog-title { font-family: var(--font-display); font-size: 20px; font-weight: 600; margin-bottom: 8px; }
+.ord-dialog-body { font-size: 13px; color: var(--muted); line-height: 1.6; margin-bottom: 22px; font-weight: 300; }
+.ord-dialog-actions { display: flex; gap: 10px; justify-content: flex-end; }
+
+/* Toast */
+.ord-toast {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  background: var(--espresso); color: var(--cream);
+  padding: 11px 20px; border-radius: 8px;
+  font-family: var(--font-mono); font-size: 12px;
+  box-shadow: var(--shadow-md); z-index: 200;
+  animation: toastIn 0.22s ease; white-space: nowrap;
+  border-left: 3px solid var(--amber);
+}
+.ord-toast.error { border-left-color: var(--red); }
+
+/* Load / Error */
+.ord-load {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 60vh; gap: 16px;
+}
+.ord-spinner {
+  width: 28px; height: 28px;
+  border: 2px solid var(--cream-3); border-top-color: var(--amber);
+  border-radius: 50%; animation: spin 0.8s linear infinite;
+}
+.ord-load-text { font-family: var(--font-mono); font-size: 12px; color: var(--muted); }
+.ord-error {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 60vh; gap: 12px;
+}
+.ord-error-msg { font-family: var(--font-mono); font-size: 13px; color: var(--red); }
+.ord-retry {
+  background: var(--espresso); color: var(--cream);
+  border: none; border-radius: 6px; padding: 8px 20px;
+  font-family: var(--font-mono); font-size: 12px; cursor: pointer;
+}
+
+/* Empty */
+.ord-empty {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 60px 20px; gap: 12px; text-align: center;
+}
+.ord-empty-title { font-family: var(--font-display); font-style: italic; font-size: 22px; color: var(--muted); }
+.ord-empty-sub   { font-family: var(--font-mono); font-size: 11px; color: var(--rule); letter-spacing: 0.5px; }
+
+@keyframes fadeUp  { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes fadeIn  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes scaleIn { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
+@keyframes toastIn { from { opacity: 0; transform: translate(-50%, 10px); } to { opacity: 1; transform: translate(-50%, 0); } }
+@keyframes spin    { to { transform: rotate(360deg); } }
+
+@media (max-width: 700px) {
+  .ord-root { padding: 20px 16px 60px; }
+  .ord-header { flex-direction: column; align-items: flex-start; }
+  .ord-title { font-size: 30px; }
+  .ord-filters { flex-direction: column; align-items: stretch; }
+  .ord-search-wrap { max-width: 100%; }
+}

--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -1,348 +1,410 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../services/api';
+import '../index.css';
 
-function Orders() {
-  const [orders, setOrders] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState('');
+/* ─── Status config ──────────────────────── */
+
+const STATUSES = ['pending', 'preparing', 'ready', 'delivered', 'cancelled'];
+
+const STATUS_CONFIG = {
+  pending:   { label: 'Pending',   color: '#b45309', bg: '#fef3c7', border: '#fde68a' },
+  preparing: { label: 'Preparing', color: '#1d4ed8', bg: '#eff6ff', border: '#bfdbfe' },
+  ready:     { label: 'Ready',     color: '#6d28d9', bg: '#f5f3ff', border: '#ddd6fe' },
+  delivered: { label: 'Delivered', color: '#065f46', bg: '#ecfdf5', border: '#a7f3d0' },
+  cancelled: { label: 'Cancelled', color: '#991b1b', bg: '#fff1f2', border: '#fecdd3' },
+};
+
+const DEFAULT_EXPANDED = { pending: true, preparing: true, ready: true, delivered: false, cancelled: false };
+
+/* ─── Helpers ────────────────────────────── */
+
+function fmtUsd(n) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency', currency: 'USD',
+    minimumFractionDigits: 2, maximumFractionDigits: 2,
+  }).format(n ?? 0);
+}
+
+function fmtDateTime(iso) {
+  if (!iso) return null;
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  });
+}
+
+/* ─── StatusPill ─────────────────────────── */
+
+function StatusPill({ status }) {
+  const cfg = STATUS_CONFIG[status] ?? { label: status, color: '#666', bg: '#f3f4f6', border: '#e5e7eb' };
+  return (
+    <span className="ord-status-pill" style={{
+      color: cfg.color, background: cfg.bg, borderColor: cfg.border,
+    }}>
+      <span className="ord-status-dot" style={{ background: cfg.color }} />
+      {cfg.label}
+    </span>
+  );
+}
+
+/* ─── ConfirmDialog ──────────────────────── */
+
+function ConfirmDialog({ orderId, onConfirm, onCancel }) {
+  return (
+    <div className="ord-overlay" onClick={onCancel}>
+      <div className="ord-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="ord-dialog-title">Delete order?</div>
+        <div className="ord-dialog-body">
+          Order <strong>#{orderId}</strong> will be permanently removed. This cannot be undone.
+        </div>
+        <div className="ord-dialog-actions">
+          <button className="btn-ghost" onClick={onCancel}>Cancel</button>
+          <button className="btn-primary" style={{ background: 'var(--red)' }} onClick={onConfirm}>
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── OrderCard ──────────────────────────── */
+
+function OrderCard({ order, onStatusChange, onDelete, delay }) {
+  return (
+    <div className="ord-card" style={{ animationDelay: `${delay}ms` }}>
+      <div className="ord-card-top">
+        <span className="ord-card-id">Order #{order.id}</span>
+        <StatusPill status={order.status} />
+      </div>
+
+      <div className="ord-card-body">
+        <div className={`ord-customer${!order.customer_name ? ' anonymous' : ''}`}>
+          {order.customer_name || 'No customer'}
+        </div>
+
+        {[
+          { label: 'Phone',   value: order.customer_phone },
+          { label: 'Address', value: order.delivery_address },
+          { label: 'Payment', value: order.payment_method === 'e-transfer' ? 'e-Transfer' : order.payment_method ? 'Cash' : null },
+          { label: 'Notes',   value: order.notes },
+        ].map(({ label, value }) => value ? (
+          <div key={label} className="ord-detail">
+            <span className="ord-detail-label">{label}</span>
+            <span className="ord-detail-value">{value}</span>
+          </div>
+        ) : null)}
+
+        {/* Items */}
+        {order.order_items?.length > 0 && (
+          <div className="ord-detail" style={{ alignItems: 'flex-start' }}>
+            <span className="ord-detail-label">Items</span>
+            <div className="ord-items">
+              {order.order_items.map((item, i) => (
+                <div key={i} className="ord-item-row">
+                  <span className="ord-item-qty">{item.quantity}×</span>
+                  <span>{item.item_name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Timestamps */}
+        {order.scheduled_date && (
+          <div className="ord-detail">
+            <span className="ord-detail-label">Sched.</span>
+            <span className="ord-detail-value">{fmtDateTime(order.scheduled_date)}</span>
+          </div>
+        )}
+        <div className="ord-detail">
+          <span className="ord-detail-label">Created</span>
+          <span className="ord-detail-value">{fmtDateTime(order.created_at)}</span>
+        </div>
+        {order.updated_at && order.updated_at !== order.created_at && (
+          <div className="ord-detail">
+            <span className="ord-detail-label">Updated</span>
+            <span className="ord-detail-value">{fmtDateTime(order.updated_at)}</span>
+          </div>
+        )}
+
+        <div className="ord-total">
+          <span className="ord-total-label">Total</span>
+          <span className="ord-total-value">{fmtUsd(order.total_amount)}</span>
+        </div>
+      </div>
+
+      <div className="ord-card-footer">
+        <Link to={`/orders/${order.id}/edit`} className="btn-primary">Edit</Link>
+        <select
+          className="ord-status-select"
+          value={order.status}
+          onChange={(e) => onStatusChange(order, e.target.value)}
+        >
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{STATUS_CONFIG[s].label}</option>
+          ))}
+        </select>
+        <button className="btn-danger" onClick={() => onDelete(order)}>Delete</button>
+      </div>
+    </div>
+  );
+}
+
+/* ─── StatusSection ──────────────────────── */
+
+function StatusSection({ status, orders, expanded, onToggle, onStatusChange, onDelete }) {
+  const cfg = STATUS_CONFIG[status];
+  return (
+    <div className="ord-section">
+      <button
+        className="ord-section-head"
+        style={{ borderLeftColor: cfg.color }}
+        onClick={onToggle}
+      >
+        <ChevronIcon open={expanded} />
+        <span className="ord-status-dot ord-section-dot" style={{ background: cfg.color }} />
+        <span className="ord-section-label" style={{ color: cfg.color }}>{cfg.label}</span>
+        <span className="ord-section-count">{orders.length}</span>
+      </button>
+
+      {expanded && (
+        <div className="ord-section-body">
+          {orders.length === 0 ? (
+            <div className="ord-empty-section">No {cfg.label.toLowerCase()} orders</div>
+          ) : (
+            <div className="ord-grid">
+              {orders.map((order, i) => (
+                <OrderCard
+                  key={order.id}
+                  order={order}
+                  delay={i * 35}
+                  onStatusChange={onStatusChange}
+                  onDelete={onDelete}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Orders ─────────────────────────────── */
+
+export default function Orders() {
+  const [orders, setOrders]     = useState([]);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(null);
+  const [search, setSearch]     = useState('');
+  const [statusFilter, setStatusFilter]   = useState('');
   const [paymentFilter, setPaymentFilter] = useState('');
-  const [expandedSections, setExpandedSections] = useState({
-    pending: true,
-    preparing: true,
-    ready: true,
-    delivered: false,
-    cancelled: false
-  });
-  const [formData, setFormData] = useState({
-    customer_id: '',
-    delivery_address: '',
-    total_amount: '',
-    notes: '',
-    scheduled_date: ''
-  });
-  const [customerData, setCustomerData] = useState({
-    name: '',
-    phone: '',
-    email: '',
-    address: ''
-  });
-  const [editingId, setEditingId] = useState(null);
-  const [showForm, setShowForm] = useState(false);
-  const [showCustomerForm, setShowCustomerForm] = useState(false);
-  const [customers, setCustomers] = useState([]);
+  const [expanded, setExpanded] = useState(DEFAULT_EXPANDED);
+  const [deleteTarget, setDeleteTarget]   = useState(null);
+  const [toast, setToast]       = useState(null);
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  /* ── Load ── */
+  const load = useCallback(async () => {
     try {
-      setLoading(true);
-      const [ordersData, customersData] = await Promise.all([
-        api.getOrders(),
-        api.getCustomers()
-      ]);
-      setOrders(ordersData);
-      setCustomers(customersData);
+      setLoading(true); setError(null);
+      const data = await api.getOrders();
+      setOrders(data || []);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  /* ── Toast ── */
+  const showToast = (msg, type = 'success') => {
+    setToast({ msg, type });
+    setTimeout(() => setToast(null), 3000);
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  /* ── Status change ── */
+  const handleStatusChange = async (order, newStatus) => {
     try {
-      const amount = parseFloat(formData.total_amount);
-      if (isNaN(amount) || amount <= 0) {
-        alert('Please enter a valid total amount');
-        return;
-      }
-      const data = {
-        ...formData,
-        customer_id: parseInt(formData.customer_id) || null,
-        total_amount: amount,
-        status: 'pending',
-        scheduled_date: formData.scheduled_date ? formData.scheduled_date + ':00Z' : null
-      };
-      if (editingId) {
-        await api.updateOrder(editingId, data);
-      } else {
-        await api.createOrder(data);
-      }
-      handleCancel();
-      loadData();
+      await api.updateOrder(order.id, {
+        customer_id:      order.customer_id,
+        delivery_address: order.delivery_address,
+        status:           newStatus,
+        total_amount:     order.total_amount,
+        notes:            order.notes,
+        scheduled_date:   order.scheduled_date,
+      });
+      load();
     } catch (err) {
-      alert(err.message);
+      showToast(err.message, 'error');
     }
   };
 
-  const handleCustomerSubmit = async (e) => {
-    e.preventDefault();
+  /* ── Delete ── */
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
     try {
-      await api.createCustomer(customerData);
-      setShowCustomerForm(false);
-      setCustomerData({ name: '', phone: '', email: '', address: '' });
-      loadData();
+      await api.deleteOrder(deleteTarget.id);
+      setDeleteTarget(null);
+      showToast('Order deleted');
+      load();
     } catch (err) {
-      alert(err.message);
+      setDeleteTarget(null);
+      showToast(err.message, 'error');
     }
   };
 
-  const handleEdit = (order) => {
-    setFormData({
-      customer_id: order.customer_id ? String(order.customer_id) : '',
-      delivery_address: order.delivery_address || '',
-      total_amount: String(order.total_amount) || '',
-      notes: order.notes,
-      payment_method: order.payment_method || '',
-      scheduled_date: order.scheduled_date ? order.scheduled_date.split('T')[0] : ''
-    });
-    setEditingId(order.id);
-    setShowForm(true);
-  };
-
-  const handleCancel = () => {
-    setShowForm(false);
-    setEditingId(null);
-    setShowCustomerForm(false);
-    setFormData({ customer_id: '', delivery_address: '', total_amount: '', notes: '', scheduled_date: '' });
-  };
-
-  const handleCustomerChange = (customerId) => {
-    const customer = customers.find(c => c.id === parseInt(customerId));
-    setFormData(prev => ({
-      ...prev,
-      customer_id: customerId,
-      delivery_address: customer?.address || prev.delivery_address
-    }));
-  };
-
-  const handleDelete = async (id) => {
-    if (!confirm('Delete this order?')) return;
-    try {
-      await api.deleteOrder(id);
-      loadData();
-    } catch (err) {
-      alert(err.message);
-    }
-  };
-
-  const statusColors = {
-    pending: '#f59e0b',
-    preparing: '#3b82f6',
-    ready: '#8b5cf6',
-    delivered: '#10b981',
-    cancelled: '#ef4444',
-  };
-
-  const statusLabels = {
-    pending: 'Pending',
-    preparing: 'Preparing',
-    ready: 'Ready',
-    delivered: 'Delivered',
-    cancelled: 'Cancelled'
-  };
-
-  const toggleSection = (status) => {
-    setExpandedSections(prev => ({
-      ...prev,
-      [status]: !prev[status]
-    }));
-  };
-
-  const expandAllSections = () => {
-    setExpandedSections({
-      pending: true,
-      preparing: true,
-      ready: true,
-      delivered: true,
-      cancelled: true
-    });
-  };
-
-  const collapseAllSections = () => {
-    setExpandedSections({
-      pending: false,
-      preparing: false,
-      ready: false,
-      delivered: false,
-      cancelled: false
-    });
-  };
-
-  const filteredOrders = orders.filter(order => {
-    const matchesSearch = !searchTerm || 
-      order.customer_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      order.delivery_address?.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesStatus = !statusFilter || order.status === statusFilter;
-    const matchesPayment = !paymentFilter || order.payment_method === paymentFilter;
-    return matchesSearch && matchesStatus && matchesPayment;
+  /* ── Filter ── */
+  const filtered = orders.filter((o) => {
+    const s = search.toLowerCase();
+    const matchSearch  = !search || o.customer_name?.toLowerCase().includes(s) || o.delivery_address?.toLowerCase().includes(s);
+    const matchStatus  = !statusFilter  || o.status          === statusFilter;
+    const matchPayment = !paymentFilter || o.payment_method  === paymentFilter;
+    return matchSearch && matchStatus && matchPayment;
   });
 
-  // Group filtered orders by status
-  const groupedOrders = {
-    pending: filteredOrders.filter(o => o.status === 'pending'),
-    preparing: filteredOrders.filter(o => o.status === 'preparing'),
-    ready: filteredOrders.filter(o => o.status === 'ready'),
-    delivered: filteredOrders.filter(o => o.status === 'delivered'),
-    cancelled: filteredOrders.filter(o => o.status === 'cancelled')
-  };
+  const grouped = Object.fromEntries(
+    STATUSES.map((s) => [s, filtered.filter((o) => o.status === s)])
+  );
 
-  // Filter statuses to show only the filtered status when statusFilter is active
-  const visibleStatuses = statusFilter 
-    ? Object.keys(groupedOrders).filter(status => status === statusFilter)
-    : Object.keys(groupedOrders);
+  const visibleStatuses = statusFilter ? [statusFilter] : STATUSES;
 
-  if (loading) return <div className="loading">Loading orders...</div>;
-  if (error) return <div className="error">Error: {error}</div>;
+  /* ── Expand / collapse ── */
+  const toggleSection  = (s) => setExpanded((p) => ({ ...p, [s]: !p[s] }));
+  const expandAll      = () => setExpanded(Object.fromEntries(STATUSES.map((s) => [s, true])));
+  const collapseAll    = () => setExpanded(Object.fromEntries(STATUSES.map((s) => [s, false])));
 
+  /* ── Render ── */
   return (
-    <div className="page">
-      <div className="page-header">
-        <h1>Orders</h1>
-      </div>
+    <>
+      <div className="ord-root">
 
-      <div className="filters">
-        <input
-          type="text"
-          placeholder="Search by customer or address..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="search-input"
-        />
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="filter-select"
-        >
-          <option value="">All Statuses</option>
-          <option value="pending">Pending</option>
-          <option value="preparing">Preparing</option>
-          <option value="ready">Ready</option>
-          <option value="delivered">Delivered</option>
-          <option value="cancelled">Cancelled</option>
-        </select>
-        <select
-          value={paymentFilter}
-          onChange={(e) => setPaymentFilter(e.target.value)}
-          className="filter-select"
-        >
-          <option value="">All Payment Methods</option>
-          <option value="cash">Cash</option>
-          <option value="e-transfer">e-Transfer</option>
-        </select>
-      </div>
+        {toast && <div className={`ord-toast ${toast.type}`}>{toast.msg}</div>}
 
-      <div className="section-controls">
-        <button className="btn-secondary" onClick={expandAllSections}>Expand All</button>
-        <button className="btn-secondary" onClick={collapseAllSections}>Collapse All</button>
-      </div>
+        {deleteTarget && (
+          <ConfirmDialog
+            orderId={deleteTarget.id}
+            onConfirm={confirmDelete}
+            onCancel={() => setDeleteTarget(null)}
+          />
+        )}
 
-      <div className="orders-by-status">
-        {visibleStatuses.map((status) => (
-          <div key={status} className="status-section">
-            <button
-              className="status-section-header"
-              onClick={() => toggleSection(status)}
-              style={{ borderLeftColor: statusColors[status] }}
-            >
-              <span className="section-toggle">
-                {expandedSections[status] ? '▼' : '▶'}
-              </span>
-              <span className="section-title">{statusLabels[status]}</span>
-              <span className="section-count">({groupedOrders[status].length})</span>
-            </button>
-            
-            {expandedSections[status] && (
-              <div className="status-section-content">
-                {groupedOrders[status].length === 0 ? (
-                  <p className="empty-section">No {statusLabels[status].toLowerCase()} orders</p>
-                ) : (
-                  <div className="card-grid">
-                    {groupedOrders[status].map((order) => (
-                      <div key={order.id} className="card">
-                        <div className="card-header">
-                          <span className="order-id">Order #{order.id}</span>
-                          <span 
-                            className="status-badge"
-                            style={{ backgroundColor: statusColors[order.status] || '#666' }}
-                          >
-                            {order.status}
-                          </span>
-                        </div>
-                        <div className="card-body">
-                          <p><strong>Customer:</strong> {order.customer_name || 'No Customer'}</p>
-                          <p><strong>Phone:</strong> {order.customer_phone || 'N/A'}</p>
-                          <p><strong>Address:</strong> {order.delivery_address}</p>
-                          <div className="order-items-list">
-                            <strong>Items:</strong>
-                            {order.order_items && order.order_items.length > 0 ? (
-                              <ul>
-                                {order.order_items.map((item, index) => (
-                                  <li key={index}>{item.quantity}x {item.item_name}</li>
-                                ))}
-                              </ul>
-                            ) : (
-                              <span className="no-items">No items</span>
-                            )}
-                          </div>
-                           <p><strong>Total:</strong> ${order.total_amount}</p>
-                            <p><strong>Payment Method:</strong> {order.payment_method === 'e-transfer' ? 'e-Transfer' : 'Cash'}</p>
-                            {order.notes && <p><strong>Notes:</strong> {order.notes}</p>}
-                             {order.scheduled_date && (
-                               <p><strong>Scheduled:</strong> {new Date(order.scheduled_date).toLocaleString('en-US')}</p>
-                             )}
-                            {order.created_at && <p><strong>Created:</strong> {new Date(order.created_at).toLocaleString('en-US')}</p>}
-                            {order.updated_at && order.updated_at !== order.created_at && (
-                            <p><strong>Updated:</strong> {new Date(order.updated_at).toLocaleString('en-US')}</p>
-                            )}
-                        </div>
-                        <div className="card-actions">
-                          <Link to={`/orders/${order.id}/edit`} className="btn-primary">Edit</Link>
-                          <select
-                            value={order.status}
-                            onChange={async (e) => {
-                              try {
-                                await api.updateOrder(order.id, {
-                                  customer_id: order.customer_id,
-                                  delivery_address: order.delivery_address,
-                                  status: e.target.value,
-                                  total_amount: order.total_amount,
-                                  notes: order.notes,
-                                  scheduled_date: order.scheduled_date
-                                });
-                                loadData();
-                              } catch (err) {
-                                alert(err.message);
-                              }
-                            }}
-                            className="status-select"
-                          >
-                            <option value="pending">Pending</option>
-                            <option value="preparing">Preparing</option>
-                            <option value="ready">Ready</option>
-                            <option value="delivered">Delivered</option>
-                            <option value="cancelled">Cancelled</option>
-                          </select>
-                          <button className="btn-danger" onClick={() => handleDelete(order.id)}>Delete</button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
+        {/* Header */}
+        <div className="ord-header">
+          <div>
+            <h1 className="ord-title">All <em>Orders</em></h1>
+            <div className="ord-meta">
+              {orders.length} order{orders.length !== 1 ? 's' : ''}
+              {filtered.length !== orders.length && ` · ${filtered.length} shown`}
+            </div>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="ord-load">
+            <div className="ord-spinner" />
+            <span className="ord-load-text">Loading orders…</span>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="ord-error">
+            <p className="ord-error-msg">{error}</p>
+            <button className="ord-retry" onClick={load}>Try again</button>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <>
+            {/* Filters */}
+            <div className="ord-filters">
+              <div className="ord-search-wrap">
+                <span className="ord-search-icon"><SearchIcon /></span>
+                <input
+                  className="ord-search"
+                  type="text"
+                  placeholder="Search customer or address…"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </div>
+              <select className="ord-select" value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}>
+                <option value="">All statuses</option>
+                {STATUSES.map((s) => (
+                  <option key={s} value={s}>{STATUS_CONFIG[s].label}</option>
+                ))}
+              </select>
+              <select className="ord-select" value={paymentFilter}
+                onChange={(e) => setPaymentFilter(e.target.value)}>
+                <option value="">All payments</option>
+                <option value="cash">Cash</option>
+                <option value="e-transfer">e-Transfer</option>
+              </select>
+            </div>
+
+            {/* Section controls */}
+            <div className="ord-controls">
+              <button className="btn-ghost" onClick={expandAll}>Expand all</button>
+              <button className="btn-ghost" onClick={collapseAll}>Collapse all</button>
+            </div>
+
+            {/* Empty state */}
+            {orders.length === 0 && (
+              <div className="ord-empty">
+                <span style={{ fontSize: 32, opacity: 0.25 }}>✦</span>
+                <div className="ord-empty-title">No orders yet</div>
+                <div className="ord-empty-sub">Orders placed from the Menu page will appear here.</div>
               </div>
             )}
-          </div>
-        ))}
+
+            {orders.length > 0 && filtered.length === 0 && (
+              <div className="ord-empty">
+                <div className="ord-empty-title">No results</div>
+                <div className="ord-empty-sub">Try adjusting your filters.</div>
+              </div>
+            )}
+
+            {/* Status sections */}
+            {filtered.length > 0 && visibleStatuses.map((status) => (
+              <StatusSection
+                key={status}
+                status={status}
+                orders={grouped[status]}
+                expanded={expanded[status]}
+                onToggle={() => toggleSection(status)}
+                onStatusChange={handleStatusChange}
+                onDelete={(order) => setDeleteTarget(order)}
+              />
+            ))}
+          </>
+        )}
+
       </div>
-      {filteredOrders.length === 0 && <p className="empty">No orders matching your filters</p>}
-    </div>
+    </>
   );
 }
 
-export default Orders;
+/* ─── Icons ──────────────────────────────── */
+
+function ChevronIcon({ open }) {
+  return (
+    <svg className={`ord-section-chevron${open ? ' open' : ''}`}
+      width="14" height="14" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Orders page redesign with warm editorial design (cream base, espresso text, amber accents)
- Collapsible status sections (pending, preparing, ready, delivered, cancelled)
- Order cards with customer info, items list, and inline status change
- Search and filter by status/payment
- Expand/collapse all section controls
- Confirm dialog for delete functionality
- Toast notifications for success/error feedback
- Use CSS animations (fadeUp, fadeIn, scaleIn, toastIn, spin)
- Keep design tokens consistent with other pages (Navbar, Dashboard, Home, Schedule, Customers, Items)
- Build passes successfully