### PR TITLE
fix: highlight active nav link for /orders/:id/edit route (Issue #173)

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -25,6 +25,8 @@ function OrderEditWrapper() {
 function Navbar() {
   const { pathname } = useLocation()
 
+  const isActive = (path) => path === '/' ? pathname === '/' : pathname.startsWith(path)
+
   return (
     <nav className="nav">
       <Link className="nav-brand" to="/">
@@ -40,7 +42,7 @@ function Navbar() {
           <Link
             key={path}
             to={path}
-            className={`nav-link${pathname === path ? ' active' : ''}`}
+            className={`nav-link${isActive(path) ? ' active' : ''}`}
           >
             {label}
           </Link>


### PR DESCRIPTION
## Summary
- Fixes Issue #173: Active link not highlighted for /orders/:id/edit route
- Added isActive helper function that checks if pathname starts with path (except for exact match on '/')
- Orders link now highlights correctly when on any /orders/* route including /orders/:id/edit
- Build passes successfully

Closes #173