### PR TITLE
fix: remove unused useRef import (Issue #175)

### DIFF
--- a/web/src/pages/Items.jsx
+++ b/web/src/pages/Items.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { api } from '../services/api';
 import '../index.css';
 


### PR DESCRIPTION
## Summary
- Fixes Issue #175: Items.jsx has unused useRef import
- Removed useRef from the react import since it's no longer used
- Build passes successfully

Closes #175