### PR TITLE
fix: include payment_method in Orders.jsx status change (Issue #178)

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -233,6 +233,7 @@ export default function Orders() {
         customer_id:      order.customer_id,
         delivery_address: order.delivery_address,
         status:           newStatus,
+        payment_method:  order.payment_method,
         total_amount:     order.total_amount,
         notes:            order.notes,
         scheduled_date:   order.scheduled_date,


### PR DESCRIPTION
## Summary
- Fixes Issue #178: Orders.jsx status change omits payment_method
- Added payment_method to the api.updateOrder call to prevent wiping the payment method when changing status
- Build passes successfully

Closes #178