### PR TITLE
fix: add thousand separator to Total Orders KPI sub-label (Issue #182)

### DIFF
--- a/web/src/pages/Dashboard.jsx
+++ b/web/src/pages/Dashboard.jsx
@@ -392,7 +392,7 @@ export default function Dashboard() {
                 <KpiCard label="Daily Revenue"   value={s.daily_revenue}      isCurrency delay={120} accent />
                 <KpiCard label="Avg Order Value" value={s.average_order_value} isCurrency delay={180} />
                 <KpiCard label="Total Orders"    value={s.total_orders}       delay={240}
-                  sub={`${s.monthly_orders} this month`} />
+                  sub={`${fmt.num(s.monthly_orders ?? 0)} this month`} />
                 <KpiCard label="Today's Orders"  value={s.daily_orders}       delay={300}
                   sub={`${fmt.usd(s.daily_revenue)} revenue`} />
               </div>


### PR DESCRIPTION
## Summary
- Fixes Issue #182: Total Orders KPI sub-label missing thousand separator
- Changed \`\${s.monthly_orders} this month\` to \`\${fmt.num(s.monthly_orders ?? 0)} this month\`
- Now displays "1,234 this month" instead of "1234 this month"
- Build passes successfully

Closes #182