### PR TITLE
fix: reset quantities when cancelling order form (Issue #184)

### DIFF
--- a/web/src/pages/Items.jsx
+++ b/web/src/pages/Items.jsx
@@ -274,6 +274,7 @@ export default function Items() {
     setOrderForm(EMPTY_ORDER_FORM);
     setOrderFormError(null);
     setOrderHistory([]);
+    resetQty();
   };
 
   const handleCustomerChange = async (customerId) => {


### PR DESCRIPTION
## Summary
- Fixes Issue #184: Cancelling the order form doesn't reset quantities
- Added resetQty() call at the end of closeOrderForm function
- Now when user clicks Cancel or the X button, item quantities are reset
- Build passes successfully

Closes #184