### PR TITLE
fix: validate at least one item before saving order (Issue #185)

### DIFF
--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -165,6 +165,10 @@ export default function OrderEdit() {
 
   /* ── Save ── */
   const handleSave = async () => {
+    if (selectedItems.length === 0) {
+      setSaveError("Add at least one item to the order before saving.");
+      return;
+    }
     setSaving(true); setSaveError(null);
     try {
       await api.updateOrder(parseInt(id), {


### PR DESCRIPTION
## Summary
- Fixes Issue #185: No validation before saving with zero items
- Added guard to check if selectedItems.length === 0 before saving
- Shows error message "Add at least one to the order before saving." when validation fails
- Build passes successfully

Closes #185