### PR TITLE
fix: use item_id as key in Orders.jsx order items (Issue #174)

### DIFF
--- a/web/src/pages/Orders.jsx
+++ b/web/src/pages/Orders.jsx
@@ -102,7 +102,7 @@ function OrderCard({ order, onStatusChange, onDelete, delay }) {
             <span className="ord-detail-label">Items</span>
             <div className="ord-items">
               {order.order_items.map((item, i) => (
-                <div key={i} className="ord-item-row">
+                <div key={item.item_id ?? i} className="ord-item-row">
                   <span className="ord-item-qty">{item.quantity}×</span>
                   <span>{item.item_name}</span>
                 </div>


### PR DESCRIPTION
## Summary
- Fixes Issue #174: Orders.jsx uses array index as key for order items
- Changed key={i} to key={item.item_id ?? i} to properly identify items
- Build passes successfully

Closes #174