### PR TITLE
fix: display order history items on separate lines (Issue #176)

### DIFF
--- a/web/src/pages/Items.jsx
+++ b/web/src/pages/Items.jsx
@@ -493,9 +493,13 @@ export default function Items() {
                                 <span className="ord-hist-date">{fmtDate(order.created_at)}</span>
                               </div>
                               <div className="ord-hist-items">
-                                {order.order_items?.length
-                                  ? order.order_items.map((i) => `${i.quantity}× ${i.item_name}`).join(', ')
-                                  : 'No items'}
+                                {order.order_items?.length > 0 ? (
+                                  <div>
+                                    {order.order_items.map((i) => (
+                                      <div key={i.item_id}>{i.quantity}× {i.item_name}</div>
+                                    ))}
+                                  </div>
+                                ) : 'No items'}
                               </div>
                               <div className="ord-hist-footer">
                                 <span className="ord-hist-total">{fmtUsd(order.total_amount)}</span>

--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -326,9 +326,13 @@ export default function OrderEdit() {
                           <span className="oe-hist-date">{fmtDate(o.created_at)}</span>
                         </div>
                         <div className="oe-hist-items">
-                          {o.order_items?.length
-                            ? o.order_items.map((i) => `${i.quantity}× ${i.item_name}`).join(', ')
-                            : 'No items'}
+                          {o.order_items?.length > 0 ? (
+                            <div>
+                              {o.order_items.map((i) => (
+                                <div key={i.item_id}>{i.quantity}× {i.item_name}</div>
+                              ))}
+                            </div>
+                          ) : 'No items'}
                         </div>
                         <div className="oe-hist-footer">
                           <span className="oe-hist-total">{fmtUsd(o.total_amount)}</span>


### PR DESCRIPTION
## Summary
- Fixes Issue #176: Order history items displayed as comma-separated string
- Changed Items.jsx and OrderEdit.jsx to display each item on a separate line instead of joining with comma
- Now consistent with Schedule page display
- Build passes successfully

Closes #176