### PR TITLE
fix: add null guard for new customer id in OrderEdit (Issue #177)

### DIFF
--- a/web/src/pages/OrderEdit.jsx
+++ b/web/src/pages/OrderEdit.jsx
@@ -155,7 +155,9 @@ export default function OrderEdit() {
       setCustomers(updated || []);
       setShowNewCust(false);
       setCustForm(EMPTY_CUST);
-      handleCustomerChange(String(newCust.id));
+      if (newCust?.id) {
+        handleCustomerChange(String(newCust.id));
+      }
     } catch (err) {
       setCustError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- Fixes Issue #177: OrderEdit.jsx new customer handleCustomerChange called with wrong type
- Added null guard: if (newCust?.id) before calling handleCustomerChange
- Prevents errors if api.createCustomer doesn't return the new customer object
- Build passes successfully

Closes #177