### PR TITLE
fix: resolve item handler bugs (Issues #210-214)

### DIFF
--- a/internal/handlers/item.go
+++ b/internal/handlers/item.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"database/sql"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -26,13 +28,21 @@ func scanItem(row interface {
 	return i, err
 }
 
+// trimItem returns a copy of input with all string fields whitespace-trimmed.
+func trimItem(input models.Item) models.Item {
+	input.Name = strings.TrimSpace(input.Name)
+	input.Description = strings.TrimSpace(input.Description)
+	input.Category = strings.TrimSpace(input.Category)
+	return input
+}
+
 // validateItem returns false and writes an error response if the item input is invalid.
 func validateItem(c *gin.Context, input models.Item) bool {
-	if strings.TrimSpace(input.Name) == "" {
+	if input.Name == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Name is required"})
 		return false
 	}
-	if strings.TrimSpace(input.Category) == "" {
+	if input.Category == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Category is required"})
 		return false
 	}
@@ -72,15 +82,18 @@ func GetItems(c *gin.Context) {
 // GetItem returns a single item by ID.
 func GetItem(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
 		return
 	}
 
 	row := database.DB.QueryRow(itemQuery+` WHERE id = $1`, id)
 	i, err := scanItem(row)
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Item not found"})
+		return
+	} else if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -94,6 +107,7 @@ func CreateItem(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	input = trimItem(input)
 	if !validateItem(c, input) {
 		return
 	}
@@ -109,14 +123,19 @@ func CreateItem(c *gin.Context) {
 		return
 	}
 
-	input.ID = id
-	c.JSON(http.StatusCreated, input)
+	created, err := scanItem(database.DB.QueryRow(itemQuery+` WHERE id = $1`, id))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, created)
 }
 
 // UpdateItem updates an existing menu item by ID.
 func UpdateItem(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
 		return
 	}
@@ -126,17 +145,22 @@ func UpdateItem(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	input = trimItem(input)
 	if !validateItem(c, input) {
 		return
 	}
 
-	_, err = database.DB.Exec(`
+	result, err := database.DB.Exec(`
 		UPDATE items
 		SET name = $1, description = $2, price = $3, category = $4, available = $5, updated_at = CURRENT_TIMESTAMP
 		WHERE id = $6
 	`, input.Name, input.Description, input.Price, input.Category, input.Available, id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if n, _ := result.RowsAffected(); n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Item not found"})
 		return
 	}
 
@@ -146,16 +170,20 @@ func UpdateItem(c *gin.Context) {
 // DeactivateItem marks an item as unavailable without deleting it.
 func DeactivateItem(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
 		return
 	}
 
-	_, err = database.DB.Exec(
+	result, err := database.DB.Exec(
 		`UPDATE items SET available = false, updated_at = CURRENT_TIMESTAMP WHERE id = $1`, id,
 	)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if n, _ := result.RowsAffected(); n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Item not found"})
 		return
 	}
 
@@ -165,16 +193,20 @@ func DeactivateItem(c *gin.Context) {
 // ActivateItem marks an item as available.
 func ActivateItem(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
 		return
 	}
 
-	_, err = database.DB.Exec(
+	result, err := database.DB.Exec(
 		`UPDATE items SET available = true, updated_at = CURRENT_TIMESTAMP WHERE id = $1`, id,
 	)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if n, _ := result.RowsAffected(); n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Item not found"})
 		return
 	}
 

--- a/internal/handlers/item_handlers_test.go
+++ b/internal/handlers/item_handlers_test.go
@@ -238,6 +238,9 @@ func TestCreateItem(t *testing.T) {
 				m.ExpectQuery(`INSERT INTO items`).
 					WithArgs("Pizza", "Delicious pizza", 12.99, "Main", true).
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+				m.ExpectQuery(itemQueryRegex).
+					WillReturnRows(sqlmock.NewRows(itemQueryCols).
+						AddRow(1, "Pizza", "Delicious pizza", 12.99, "Main", true, time.Now(), time.Now()))
 			},
 			expectedStatus: http.StatusCreated,
 			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
@@ -310,6 +313,9 @@ func TestCreateItem(t *testing.T) {
 				m.ExpectQuery(`INSERT INTO items`).
 					WithArgs("Burger", "Tasty burger", 8.99, "Main", false).
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(2))
+				m.ExpectQuery(itemQueryRegex).
+					WillReturnRows(sqlmock.NewRows(itemQueryCols).
+						AddRow(2, "Burger", "Tasty burger", 8.99, "Main", false, time.Now(), time.Now()))
 			},
 			expectedStatus: http.StatusCreated,
 			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
@@ -553,7 +559,7 @@ func TestDeactivateItem(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
-			// Deactivating a non-existent item is idempotent — still returns 200
+			// Deactivating a non-existent item now returns 404
 			name:   "Deactivates non-existent item without error",
 			itemID: "999",
 			setupMock: func(m sqlmock.Sqlmock) {
@@ -561,11 +567,11 @@ func TestDeactivateItem(t *testing.T) {
 					WithArgs(999).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			},
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusNotFound,
 			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
 				var resp map[string]string
 				assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-				assert.Equal(t, "Item deactivated", resp["message"])
+				assert.Equal(t, "Item not found", resp["error"])
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Fix Bug #210: Add id <= 0 guard to GetItem, UpdateItem, DeactivateItem, ActivateItem
- Fix Bug #211: GetItem returns 404 for sql.ErrNoRows, 500 for other errors
- Fix Bug #212: Add trimItem helper and use it in CreateItem/UpdateItem
- Fix Bug #213: CreateItem fetches full record after INSERT for DB timestamps
- Fix Bug #214: UpdateItem, DeactivateItem, ActivateItem return 404 when item not found

## Changes

### Bug #210 - Missing id <= 0 guard
- Added `|| id <= 0` check to GetItem, UpdateItem, DeactivateItem, and ActivateItem

### Bug #211 - GetItem error handling
- Changed to use `errors.Is(err, sql.ErrNoRows)` for proper 404 vs 500 distinction

### Bug #212 - Whitespace trimming
- Added `trimItem()` helper function
- Called in both CreateItem and UpdateItem before validation

### Bug #213 - CreateItem timestamps
- After INSERT, now fetches full record with `scanItem()` to get DB-generated timestamps

### Bug #214 - Return 404 when item not found
- UpdateItem, DeactivateItem, ActivateItem now check `RowsAffected()` and return 404 if no rows affected

### Tests Updated
- CreateItem tests now mock the SELECT query after INSERT
- DeactivateItem test now expects 404 for non-existent item