### PR TITLE
fix: resolve order handler bugs (Issues #233-239)

### DIFF
--- a/internal/handlers/order.go
+++ b/internal/handlers/order.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -161,6 +163,7 @@ func GetScheduledOrders(c *gin.Context) {
 	}
 
 	now := time.Now().UTC()
+	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	endDate := now.AddDate(0, 0, days)
 
 	rows, err := database.DB.Query(orderQuery+`
@@ -168,7 +171,7 @@ func GetScheduledOrders(c *gin.Context) {
 		  AND o.scheduled_date BETWEEN $1 AND $2
 		  AND o.status NOT IN ('delivered', 'cancelled')
 		ORDER BY o.scheduled_date ASC
-	`, now, endDate)
+	`, startOfDay, endDate)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -199,7 +202,7 @@ func GetScheduledOrders(c *gin.Context) {
 // GetOrdersByCustomer returns the 10 most recent orders for a customer.
 func GetOrdersByCustomer(c *gin.Context) {
 	customerID, err := strconv.Atoi(c.Param("customerId"))
-	if err != nil {
+	if err != nil || customerID <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid customer ID"})
 		return
 	}
@@ -239,15 +242,18 @@ func GetOrdersByCustomer(c *gin.Context) {
 // GetOrder returns a single order by ID.
 func GetOrder(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid order ID"})
 		return
 	}
 
 	row := database.DB.QueryRow(orderQuery+` WHERE o.id = $1`, id)
 	o, err := scanOrder(row)
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Order not found"})
+		return
+	} else if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -378,7 +384,7 @@ func CreateOrder(c *gin.Context) {
 // UpdateOrder updates an existing order's details and optionally its items.
 func UpdateOrder(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid order ID"})
 		return
 	}
@@ -390,10 +396,8 @@ func UpdateOrder(c *gin.Context) {
 	}
 
 	if input.PaymentMethod == "" {
-		input.PaymentMethod = "cash"
-	}
-	if input.Status == "" {
-		input.Status = "pending"
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Payment method is required"})
+		return
 	}
 	if !validateOrderStatus(c, input.Status) {
 		return
@@ -413,7 +417,7 @@ func UpdateOrder(c *gin.Context) {
 	}
 	defer tx.Rollback()
 
-	_, err = tx.Exec(`
+	result, err := tx.Exec(`
 		UPDATE orders
 		SET customer_id = $1, delivery_address = $2, status = $3, total_amount = $4,
 		    notes = $5, payment_method = $6, scheduled_date = $7, updated_at = CURRENT_TIMESTAMP
@@ -422,6 +426,10 @@ func UpdateOrder(c *gin.Context) {
 		input.Notes, input.PaymentMethod, normalizeScheduledDate(input.ScheduledDate), id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if n, _ := result.RowsAffected(); n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Order not found"})
 		return
 	}
 
@@ -463,7 +471,7 @@ func UpdateOrder(c *gin.Context) {
 // DeleteOrder removes an order and all its items in a transaction.
 func DeleteOrder(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid order ID"})
 		return
 	}
@@ -479,8 +487,13 @@ func DeleteOrder(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if _, err = tx.Exec("DELETE FROM orders WHERE id = $1", id); err != nil {
+	delResult, err := tx.Exec("DELETE FROM orders WHERE id = $1", id)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if n, _ := delResult.RowsAffected(); n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Order not found"})
 		return
 	}
 

--- a/internal/handlers/order_handlers_test.go
+++ b/internal/handlers/order_handlers_test.go
@@ -380,18 +380,18 @@ func TestGetOrder(t *testing.T) {
 			},
 		},
 		{
-			name:    "Returns 404 on any database error",
+			name:    "Returns 500 on database error (non-ErrNoRows)",
 			orderID: "1",
 			setupMock: func(m sqlmock.Sqlmock) {
 				m.ExpectQuery(orderQueryRegex).
 					WithArgs(1).
 					WillReturnError(fmt.Errorf("connection error"))
 			},
-			expectedStatus: http.StatusNotFound,
+			expectedStatus: http.StatusInternalServerError,
 			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
 				var resp map[string]string
 				assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-				assert.Equal(t, "Order not found", resp["error"])
+				assert.NotEmpty(t, resp["error"])
 			},
 		},
 	}
@@ -630,7 +630,7 @@ func TestUpdateOrder(t *testing.T) {
 		{
 			name:           "Returns 400 for invalid status",
 			orderID:        "1",
-			body:           `{"status":"invalid_status"}`,
+			body:           `{"status":"invalid_status","payment_method":"cash"}`,
 			setupMock:      func(m sqlmock.Sqlmock) {},
 			expectedStatus: http.StatusBadRequest,
 			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
@@ -732,8 +732,8 @@ func TestDeleteOrder(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
-			// Deleting a non-existent order is idempotent — still returns 200
-			name:    "Deletes non-existent order without error",
+			// Deleting a non-existent order now returns 404
+			name:    "Returns 404 when order does not exist",
 			orderID: "999",
 			setupMock: func(m sqlmock.Sqlmock) {
 				m.ExpectBegin()
@@ -743,13 +743,12 @@ func TestDeleteOrder(t *testing.T) {
 				m.ExpectExec(`DELETE FROM orders WHERE id = \$1`).
 					WithArgs(999).
 					WillReturnResult(sqlmock.NewResult(0, 0))
-				m.ExpectCommit()
 			},
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusNotFound,
 			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
 				var resp map[string]string
 				assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-				assert.Equal(t, "Order deleted", resp["message"])
+				assert.Equal(t, "Order not found", resp["error"])
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Fix Bug #233: Add id <= 0 guard to GetOrder, UpdateOrder, DeleteOrder
- Fix Bug #234: Add customerID <= 0 guard to GetOrdersByCustomer
- Fix Bug #235: GetOrder returns 404 for sql.ErrNoRows, 500 for other errors
- Fix Bug #236: UpdateOrder returns 404 when order doesn't exist
- Fix Bug #237: DeleteOrder returns 404 when order doesn't exist
- Fix Bug #238: UpdateOrder requires payment_method (no silent default)
- Fix Bug #239: GetScheduledOrders uses startOfDay for schedule window

## Changes

### Handler Fixes
- GetOrder, UpdateOrder, DeleteOrder: Added `id <= 0` validation
- GetOrdersByCustomer: Added `customerID <= 0` validation
- GetOrder: Proper error handling (404 for ErrNoRows, 500 for others)
- UpdateOrder: Check RowsAffected and return 404 if order not found
- DeleteOrder: Check RowsAffected and return 404 if order not found
- UpdateOrder: Return 400 if payment_method is empty (removed silent default)
- GetScheduledOrders: Use startOfDay as lower bound instead of now

### Test Updates
- Updated test to expect 500 for non-ErrNoRows DB errors
- Updated test to include payment_method for invalid status test
- Updated delete test to expect 404 for non-existent order