### PR TITLE
fix: refresh page when clicking active nav item

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -43,6 +43,7 @@ function Navbar() {
             key={path}
             to={path}
             className={`nav-link${isActive(path) ? ' active' : ''}`}
+            onClick={isActive(path) ? () => window.location.reload() : undefined}
           >
             {label}
           </Link>


### PR DESCRIPTION
## Summary
- Added onClick handler to nav links that reloads the page when clicking an already-active nav item
- Fixes UX issue where clicking active nav item did nothing

## Changes
- `web/src/App.jsx`:
  - Added `onClick={isActive(path) ? () => window.location.reload() : undefined}` to nav Links

Closes #261